### PR TITLE
feat: error handling for authorization pending in device flow

### DIFF
--- a/handler/oauth2/flow_authorize_code_token.go
+++ b/handler/oauth2/flow_authorize_code_token.go
@@ -23,7 +23,7 @@ func (c AuthorizeCodeHandler) Code(ctx context.Context, requester fosite.AccessR
 	return code, signature, nil
 }
 
-func (c AuthorizeCodeHandler) ValidateCode(ctx context.Context, requester fosite.AccessRequester, code string) error {
+func (c AuthorizeCodeHandler) ValidateCode(ctx context.Context, requester fosite.Requester, code string) error {
 	return c.AuthorizeCodeStrategy.ValidateAuthorizeCode(ctx, requester, code)
 }
 

--- a/handler/oauth2/flow_authorize_code_token_test.go
+++ b/handler/oauth2/flow_authorize_code_token_test.go
@@ -21,242 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
-	for k, strategy := range map[string]CoreStrategy{
-		"hmac": &hmacshaStrategy,
-	} {
-		t.Run("strategy="+k, func(t *testing.T) {
-			store := storage.NewMemoryStore()
-			config := &fosite.Config{
-				ScopeStrategy:            fosite.HierarchicScopeStrategy,
-				AudienceMatchingStrategy: fosite.DefaultAudienceMatchingStrategy,
-				AuthorizeCodeLifespan:    time.Minute,
-			}
-			h := GenericCodeTokenEndpointHandler{
-				AccessRequestValidator: &AuthorizeExplicitGrantAccessRequestValidator{},
-				CodeHandler: &AuthorizeCodeHandler{
-					AuthorizeCodeStrategy: strategy,
-				},
-				SessionHandler: &AuthorizeExplicitGrantSessionHandler{
-					AuthorizeCodeStorage: store,
-				},
-				TokenRevocationStorage: store,
-				Config:                 config,
-			}
-
-			testCases := []struct {
-				description string
-				areq        *fosite.AccessRequest
-				authreq     *fosite.AuthorizeRequest
-				setup       func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest)
-				check       func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest)
-				expectErr   error
-			}{
-				{
-					description: "should fail because not responsible",
-					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"12345678"},
-					},
-					expectErr: fosite.ErrUnknownRequest,
-				},
-				{
-					description: "should fail because client is not granted the correct grant type",
-					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
-						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{""}},
-							Session:     &fosite.DefaultSession{},
-							RequestedAt: time.Now().UTC(),
-						},
-					},
-					expectErr: fosite.ErrUnauthorizedClient,
-				},
-				{
-					description: "should fail because authorization code cannot be retrieved",
-					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
-						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)}},
-							Session:     &fosite.DefaultSession{},
-							RequestedAt: time.Now().UTC(),
-						},
-					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
-						token, _, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
-						require.NoError(t, err)
-						areq.Form = url.Values{"code": {token}}
-					},
-					expectErr: fosite.ErrInvalidGrant,
-				},
-				{
-					description: "should fail because authorization code is expired",
-					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
-						Request: fosite.Request{
-							Form:        url.Values{"code": {"foo.bar"}},
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)}},
-							Session:     &fosite.DefaultSession{},
-							RequestedAt: time.Now().UTC(),
-						},
-					},
-					authreq: &fosite.AuthorizeRequest{
-						Request: fosite.Request{
-							Client: &fosite.DefaultClient{ID: "foo"},
-							Session: &fosite.DefaultSession{
-								ExpiresAt: map[fosite.TokenType]time.Time{
-									fosite.AuthorizeCode: time.Now().Add(-time.Hour).UTC(),
-								},
-							},
-							RequestedAt: time.Now().Add(-2 * time.Hour).UTC(),
-						},
-					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
-						token, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
-						require.NoError(t, err)
-						areq.Form = url.Values{"code": {token}}
-
-						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
-					},
-					expectErr: fosite.ErrTokenExpired,
-				},
-				{
-					description: "should fail because client mismatch",
-					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
-						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)}},
-							Session:     &fosite.DefaultSession{},
-							RequestedAt: time.Now().UTC(),
-						},
-					},
-					authreq: &fosite.AuthorizeRequest{
-						Request: fosite.Request{
-							Client: &fosite.DefaultClient{ID: "bar"},
-							Session: &fosite.DefaultSession{
-								ExpiresAt: map[fosite.TokenType]time.Time{
-									fosite.AuthorizeCode: time.Now().Add(time.Hour).UTC(),
-								},
-							},
-						},
-					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
-						token, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
-						require.NoError(t, err)
-						areq.Form = url.Values{"code": {token}}
-
-						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
-					},
-					expectErr: fosite.ErrInvalidGrant,
-				},
-				{
-					description: "should fail because redirect uri was set during /authorize call, but not in /token call",
-					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
-						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)}},
-							Session:     &fosite.DefaultSession{},
-							RequestedAt: time.Now().UTC(),
-						},
-					},
-					authreq: &fosite.AuthorizeRequest{
-						Request: fosite.Request{
-							Client: &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)}},
-							Form:   url.Values{"redirect_uri": []string{"request-redir"}},
-							Session: &fosite.DefaultSession{
-								ExpiresAt: map[fosite.TokenType]time.Time{
-									fosite.AuthorizeCode: time.Now().Add(time.Hour).UTC(),
-								},
-							},
-						},
-					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
-						token, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
-						require.NoError(t, err)
-						areq.Form = url.Values{"code": {token}}
-
-						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
-					},
-					expectErr: fosite.ErrInvalidGrant,
-				},
-				{
-					description: "should pass",
-					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
-						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)}},
-							Form:        url.Values{"redirect_uri": []string{"request-redir"}},
-							Session:     &fosite.DefaultSession{},
-							RequestedAt: time.Now().UTC(),
-						},
-					},
-					authreq: &fosite.AuthorizeRequest{
-						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)}},
-							Session:     &fosite.DefaultSession{},
-							RequestedAt: time.Now().UTC(),
-						},
-					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
-						token, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
-						require.NoError(t, err)
-
-						areq.Form = url.Values{"code": {token}}
-						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
-					},
-				},
-				{
-					description: "should fail because code has been used already",
-					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
-						Request: fosite.Request{
-							Form:        url.Values{},
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)}},
-							Session:     &fosite.DefaultSession{},
-							RequestedAt: time.Now().UTC(),
-						},
-					},
-					authreq: &fosite.AuthorizeRequest{
-						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)}},
-							Session:     &fosite.DefaultSession{},
-							RequestedAt: time.Now().UTC(),
-						},
-					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
-						code, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
-						require.NoError(t, err)
-						areq.Form.Add("code", code)
-
-						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
-						require.NoError(t, store.InvalidateAuthorizeCodeSession(context.Background(), signature))
-					},
-					expectErr: fosite.ErrInvalidGrant,
-				},
-			}
-
-			for i, testCase := range testCases {
-				t.Run(fmt.Sprintf("case=%d/description=%s", i, testCase.description), func(t *testing.T) {
-					if testCase.setup != nil {
-						testCase.setup(t, testCase.areq, testCase.authreq)
-					}
-
-					t.Logf("Processing %+v", testCase.areq.Client)
-
-					err := h.HandleTokenEndpointRequest(context.Background(), testCase.areq)
-					if testCase.expectErr != nil {
-						require.EqualError(t, err, testCase.expectErr.Error(), "%+v", err)
-					} else {
-						require.NoError(t, err, "%+v", err)
-						if testCase.check != nil {
-							testCase.check(t, testCase.areq, testCase.authreq)
-						}
-					}
-				})
-			}
-		})
-	}
-}
-
 func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 	for k, strategy := range map[string]CoreStrategy{
 		"hmac": &hmacshaStrategy,
@@ -283,11 +47,11 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 				{
 					description: "should fail because authorization code cannot be retrieved",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: fosite.Arguments{"authorization_code"},
 							},
 							Session:     &fosite.DefaultSession{},
 							RequestedAt: time.Now().UTC(),
@@ -303,11 +67,11 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 				{
 					description: "should fail because authorization code is expired",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Form: url.Values{"code": []string{"foo.bar"}},
 							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: fosite.Arguments{"authorization_code"},
 							},
 							Session: &fosite.DefaultSession{
 								ExpiresAt: map[fosite.TokenType]time.Time{
@@ -325,11 +89,11 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 				{
 					description: "should pass with offline scope and refresh token",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode), string(fosite.GrantTypeRefreshToken)},
+								GrantTypes: fosite.Arguments{"authorization_code", "refresh_token"},
 							},
 							GrantedScope: fosite.Arguments{"foo", "offline"},
 							Session:      &fosite.DefaultSession{},
@@ -354,11 +118,11 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 				{
 					description: "should pass with refresh token always provided",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode), string(fosite.GrantTypeRefreshToken)},
+								GrantTypes: fosite.Arguments{"authorization_code", "refresh_token"},
 							},
 							GrantedScope: fosite.Arguments{"foo"},
 							Session:      &fosite.DefaultSession{},
@@ -384,11 +148,11 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 				{
 					description: "pass and response should not have refresh token",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: fosite.Arguments{"authorization_code"},
 							},
 							GrantedScope: fosite.Arguments{"foo"},
 							Session:      &fosite.DefaultSession{},
@@ -456,16 +220,252 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 	}
 }
 
+func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
+	for k, strategy := range map[string]CoreStrategy{
+		"hmac": &hmacshaStrategy,
+	} {
+		t.Run("strategy="+k, func(t *testing.T) {
+			store := storage.NewMemoryStore()
+			config := &fosite.Config{
+				ScopeStrategy:            fosite.HierarchicScopeStrategy,
+				AudienceMatchingStrategy: fosite.DefaultAudienceMatchingStrategy,
+				AuthorizeCodeLifespan:    time.Minute,
+			}
+			h := GenericCodeTokenEndpointHandler{
+				AccessRequestValidator: &AuthorizeExplicitGrantAccessRequestValidator{},
+				CodeHandler: &AuthorizeCodeHandler{
+					AuthorizeCodeStrategy: strategy,
+				},
+				SessionHandler: &AuthorizeExplicitGrantSessionHandler{
+					AuthorizeCodeStorage: store,
+				},
+				TokenRevocationStorage: store,
+				Config:                 config,
+			}
+
+			testCases := []struct {
+				description string
+				areq        *fosite.AccessRequest
+				authreq     *fosite.AuthorizeRequest
+				setup       func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest)
+				check       func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest)
+				expectErr   error
+			}{
+				{
+					description: "should fail because not responsible",
+					areq: &fosite.AccessRequest{
+						GrantTypes: fosite.Arguments{"12345678"},
+					},
+					expectErr: fosite.ErrUnknownRequest,
+				},
+				{
+					description: "should fail because client is not granted the correct grant type",
+					areq: &fosite.AccessRequest{
+						GrantTypes: fosite.Arguments{"authorization_code"},
+						Request: fosite.Request{
+							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{""}},
+							Session:     &fosite.DefaultSession{},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					expectErr: fosite.ErrUnauthorizedClient,
+				},
+				{
+					description: "should fail because authorization code cannot be retrieved",
+					areq: &fosite.AccessRequest{
+						GrantTypes: fosite.Arguments{"authorization_code"},
+						Request: fosite.Request{
+							Client:      &fosite.DefaultClient{GrantTypes: []string{"authorization_code"}},
+							Session:     &fosite.DefaultSession{},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
+						token, _, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
+						require.NoError(t, err)
+						areq.Form = url.Values{"code": {token}}
+					},
+					expectErr: fosite.ErrInvalidGrant,
+				},
+				{
+					description: "should fail because authorization code is expired",
+					areq: &fosite.AccessRequest{
+						GrantTypes: fosite.Arguments{"authorization_code"},
+						Request: fosite.Request{
+							Form:        url.Values{"code": {"foo.bar"}},
+							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"authorization_code"}},
+							Session:     &fosite.DefaultSession{},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					authreq: &fosite.AuthorizeRequest{
+						Request: fosite.Request{
+							Client: &fosite.DefaultClient{ID: "foo"},
+							Session: &fosite.DefaultSession{
+								ExpiresAt: map[fosite.TokenType]time.Time{
+									fosite.AuthorizeCode: time.Now().Add(-time.Hour).UTC(),
+								},
+							},
+							RequestedAt: time.Now().Add(-2 * time.Hour).UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
+						token, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
+						require.NoError(t, err)
+						areq.Form = url.Values{"code": {token}}
+
+						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
+					},
+					expectErr: fosite.ErrTokenExpired,
+				},
+				{
+					description: "should fail because client mismatch",
+					areq: &fosite.AccessRequest{
+						GrantTypes: fosite.Arguments{"authorization_code"},
+						Request: fosite.Request{
+							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"authorization_code"}},
+							Session:     &fosite.DefaultSession{},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					authreq: &fosite.AuthorizeRequest{
+						Request: fosite.Request{
+							Client: &fosite.DefaultClient{ID: "bar"},
+							Session: &fosite.DefaultSession{
+								ExpiresAt: map[fosite.TokenType]time.Time{
+									fosite.AuthorizeCode: time.Now().Add(time.Hour).UTC(),
+								},
+							},
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
+						token, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
+						require.NoError(t, err)
+						areq.Form = url.Values{"code": {token}}
+
+						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
+					},
+					expectErr: fosite.ErrInvalidGrant,
+				},
+				{
+					description: "should fail because redirect uri was set during /authorize call, but not in /token call",
+					areq: &fosite.AccessRequest{
+						GrantTypes: fosite.Arguments{"authorization_code"},
+						Request: fosite.Request{
+							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"authorization_code"}},
+							Session:     &fosite.DefaultSession{},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					authreq: &fosite.AuthorizeRequest{
+						Request: fosite.Request{
+							Client: &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"authorization_code"}},
+							Form:   url.Values{"redirect_uri": []string{"request-redir"}},
+							Session: &fosite.DefaultSession{
+								ExpiresAt: map[fosite.TokenType]time.Time{
+									fosite.AuthorizeCode: time.Now().Add(time.Hour).UTC(),
+								},
+							},
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
+						token, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
+						require.NoError(t, err)
+						areq.Form = url.Values{"code": {token}}
+
+						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
+					},
+					expectErr: fosite.ErrInvalidGrant,
+				},
+				{
+					description: "should pass",
+					areq: &fosite.AccessRequest{
+						GrantTypes: fosite.Arguments{"authorization_code"},
+						Request: fosite.Request{
+							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"authorization_code"}},
+							Form:        url.Values{"redirect_uri": []string{"request-redir"}},
+							Session:     &fosite.DefaultSession{},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					authreq: &fosite.AuthorizeRequest{
+						Request: fosite.Request{
+							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"authorization_code"}},
+							Session:     &fosite.DefaultSession{},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
+						token, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
+						require.NoError(t, err)
+
+						areq.Form = url.Values{"code": {token}}
+						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
+					},
+				},
+				{
+					description: "should fail because code has been used already",
+					areq: &fosite.AccessRequest{
+						GrantTypes: fosite.Arguments{"authorization_code"},
+						Request: fosite.Request{
+							Form:        url.Values{},
+							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: fosite.Arguments{"authorization_code"}},
+							Session:     &fosite.DefaultSession{},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					authreq: &fosite.AuthorizeRequest{
+						Request: fosite.Request{
+							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"authorization_code"}},
+							Session:     &fosite.DefaultSession{},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
+						code, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
+						require.NoError(t, err)
+						areq.Form.Add("code", code)
+
+						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
+						require.NoError(t, store.InvalidateAuthorizeCodeSession(context.Background(), signature))
+					},
+					expectErr: fosite.ErrInvalidGrant,
+				},
+			}
+
+			for i, testCase := range testCases {
+				t.Run(fmt.Sprintf("case=%d/description=%s", i, testCase.description), func(t *testing.T) {
+					if testCase.setup != nil {
+						testCase.setup(t, testCase.areq, testCase.authreq)
+					}
+
+					t.Logf("Processing %+v", testCase.areq.Client)
+
+					err := h.HandleTokenEndpointRequest(context.Background(), testCase.areq)
+					if testCase.expectErr != nil {
+						require.EqualError(t, err, testCase.expectErr.Error(), "%+v", err)
+					} else {
+						require.NoError(t, err, "%+v", err)
+						if testCase.check != nil {
+							testCase.check(t, testCase.areq, testCase.authreq)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestAuthorizeCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 	var mockTransactional *internal.MockTransactional
 	var mockCoreStore *internal.MockCoreStorage
 	var mockAuthorizeStore *internal.MockAuthorizeCodeStorage
 	strategy := hmacshaStrategy
 	request := &fosite.AccessRequest{
-		GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+		GrantTypes: fosite.Arguments{"authorization_code"},
 		Request: fosite.Request{
 			Client: &fosite.DefaultClient{
-				GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode), string(fosite.GrantTypeRefreshToken)},
+				GrantTypes: fosite.Arguments{"authorization_code", "refresh_token"},
 			},
 			GrantedScope: fosite.Arguments{"offline"},
 			Session:      &fosite.DefaultSession{},

--- a/handler/oauth2/flow_generic_code_token.go
+++ b/handler/oauth2/flow_generic_code_token.go
@@ -36,7 +36,7 @@ type CodeHandler interface {
 	Code(ctx context.Context, requester fosite.AccessRequester) (code string, signature string, err error)
 
 	// ValidateCode validates the code.
-	ValidateCode(ctx context.Context, requester fosite.AccessRequester, code string) error
+	ValidateCode(ctx context.Context, requester fosite.Requester, code string) error
 }
 
 // SessionHandler handles session-related operations.
@@ -175,7 +175,7 @@ func (c *GenericCodeTokenEndpointHandler) HandleTokenEndpointRequest(ctx context
 		return err
 	}
 
-	if err = c.ValidateCode(ctx, requester, code); err != nil {
+	if err = c.ValidateCode(ctx, ar, code); err != nil {
 		return errorsx.WithStack(err)
 	}
 

--- a/handler/rfc8628/auth_handler.go
+++ b/handler/rfc8628/auth_handler.go
@@ -36,7 +36,7 @@ func (d *DeviceAuthHandler) HandleDeviceEndpointRequest(ctx context.Context, dar
 	}
 
 	// Store the User Code session (this has no real data other that the user and device code), can be converted into a 'full' session after user auth
-	dar.GetSession().SetExpiresAt(fosite.AuthorizeCode, time.Now().UTC().Add(d.Config.GetDeviceAndUserCodeLifespan(ctx)))
+	dar.GetSession().SetExpiresAt(fosite.DeviceCode, time.Now().UTC().Add(d.Config.GetDeviceAndUserCodeLifespan(ctx)))
 	if err := d.Storage.CreateDeviceCodeSession(ctx, deviceCodeSignature, dar.Sanitize(nil)); err != nil {
 		return errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebug(err.Error()))
 	}

--- a/handler/rfc8628/token_handler.go
+++ b/handler/rfc8628/token_handler.go
@@ -34,7 +34,7 @@ func (c DeviceCodeHandler) Code(ctx context.Context, requester fosite.AccessRequ
 	return
 }
 
-func (c DeviceCodeHandler) ValidateCode(ctx context.Context, requester fosite.AccessRequester, code string) error {
+func (c DeviceCodeHandler) ValidateCode(ctx context.Context, requester fosite.Requester, code string) error {
 	return c.DeviceCodeStrategy.ValidateDeviceCode(ctx, requester, code)
 }
 

--- a/handler/rfc8628/token_handler_test.go
+++ b/handler/rfc8628/token_handler_test.go
@@ -45,218 +45,6 @@ var RFC8628HMACSHAStrategy = DefaultDeviceStrategy{
 	},
 }
 
-func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
-	for k, strategy := range map[string]struct {
-		oauth2.CoreStrategy
-		RFC8628CodeStrategy
-	}{
-		"hmac": {&hmacshaStrategy, &RFC8628HMACSHAStrategy},
-	} {
-		t.Run("strategy="+k, func(t *testing.T) {
-			store := storage.NewMemoryStore()
-
-			var h oauth2.GenericCodeTokenEndpointHandler
-			for _, c := range []struct {
-				areq        *fosite.AccessRequest
-				description string
-				setup       func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config)
-				check       func(t *testing.T, aresp *fosite.AccessResponse)
-				expectErr   error
-			}{
-				{
-					description: "should fail because not responsible",
-					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"123"},
-					},
-					expectErr: fosite.ErrUnknownRequest,
-				},
-				{
-					description: "should fail because device code cannot be retrieved",
-					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
-						Request: fosite.Request{
-							Form: url.Values{},
-							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
-							},
-							Session:     &DefaultDeviceFlowSession{},
-							RequestedAt: time.Now().UTC(),
-						},
-					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
-						code, _, err := strategy.GenerateDeviceCode(context.TODO())
-						require.NoError(t, err)
-						areq.Form.Set("device_code", code)
-					},
-					expectErr: fosite.ErrServerError,
-				},
-				{
-					description: "should fail because device code is expired",
-					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
-						Request: fosite.Request{
-							Form: url.Values{},
-							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
-							},
-							Session: &DefaultDeviceFlowSession{
-								ExpiresAt: map[fosite.TokenType]time.Time{
-									fosite.DeviceCode: time.Now().Add(-time.Hour).UTC(),
-								},
-								BrowserFlowCompleted: true,
-							},
-							RequestedAt: time.Now().Add(-2 * time.Hour).UTC(),
-						},
-					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
-						code, signature, err := strategy.GenerateDeviceCode(context.TODO())
-						require.NoError(t, err)
-						areq.Form.Add("device_code", code)
-
-						require.NoError(t, store.CreateDeviceCodeSession(context.Background(), signature, areq))
-					},
-					expectErr: fosite.ErrInvalidRequest,
-				},
-				{
-					description: "should pass with offline scope and refresh token",
-					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
-						Request: fosite.Request{
-							Form: url.Values{},
-							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode), string(fosite.GrantTypeRefreshToken)},
-							},
-							GrantedScope: fosite.Arguments{"foo", "offline"},
-							Session: &DefaultDeviceFlowSession{
-								BrowserFlowCompleted: true,
-							},
-							RequestedAt: time.Now().UTC(),
-						},
-					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
-						code, signature, err := strategy.GenerateDeviceCode(context.TODO())
-						require.NoError(t, err)
-						areq.Form.Add("device_code", code)
-
-						require.NoError(t, store.CreateDeviceCodeSession(context.TODO(), signature, areq))
-					},
-					check: func(t *testing.T, aresp *fosite.AccessResponse) {
-						assert.NotEmpty(t, aresp.AccessToken)
-						assert.Equal(t, "bearer", aresp.TokenType)
-						assert.NotEmpty(t, aresp.GetExtra("refresh_token"))
-						assert.NotEmpty(t, aresp.GetExtra("expires_in"))
-						assert.Equal(t, "foo offline", aresp.GetExtra("scope"))
-					},
-				},
-				{
-					description: "should pass with refresh token always provided",
-					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
-						Request: fosite.Request{
-							Form: url.Values{},
-							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode), string(fosite.GrantTypeRefreshToken)},
-							},
-							GrantedScope: fosite.Arguments{"foo"},
-							Session: &DefaultDeviceFlowSession{
-								BrowserFlowCompleted: true,
-							},
-							RequestedAt: time.Now().UTC(),
-						},
-					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
-						config.RefreshTokenScopes = []string{}
-						code, signature, err := strategy.GenerateDeviceCode(context.TODO())
-						require.NoError(t, err)
-						areq.Form.Add("device_code", code)
-
-						require.NoError(t, store.CreateDeviceCodeSession(context.TODO(), signature, areq))
-					},
-					check: func(t *testing.T, aresp *fosite.AccessResponse) {
-						assert.NotEmpty(t, aresp.AccessToken)
-						assert.Equal(t, "bearer", aresp.TokenType)
-						assert.NotEmpty(t, aresp.GetExtra("refresh_token"))
-						assert.NotEmpty(t, aresp.GetExtra("expires_in"))
-						assert.Equal(t, "foo", aresp.GetExtra("scope"))
-					},
-				},
-				{
-					description: "pass and response should not have refresh token",
-					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
-						Request: fosite.Request{
-							Form: url.Values{},
-							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
-							},
-							GrantedScope: fosite.Arguments{"foo"},
-							Session: &DefaultDeviceFlowSession{
-								BrowserFlowCompleted: true,
-							},
-							RequestedAt: time.Now().UTC(),
-						},
-					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
-						code, signature, err := strategy.GenerateDeviceCode(context.TODO())
-						require.NoError(t, err)
-						areq.Form.Add("device_code", code)
-
-						require.NoError(t, store.CreateDeviceCodeSession(context.TODO(), signature, areq))
-					},
-					check: func(t *testing.T, aresp *fosite.AccessResponse) {
-						assert.NotEmpty(t, aresp.AccessToken)
-						assert.Equal(t, "bearer", aresp.TokenType)
-						assert.Empty(t, aresp.GetExtra("refresh_token"))
-						assert.NotEmpty(t, aresp.GetExtra("expires_in"))
-						assert.Equal(t, "foo", aresp.GetExtra("scope"))
-					},
-				},
-			} {
-				t.Run("case="+c.description, func(t *testing.T) {
-					config := &fosite.Config{
-						ScopeStrategy:            fosite.HierarchicScopeStrategy,
-						AudienceMatchingStrategy: fosite.DefaultAudienceMatchingStrategy,
-						AccessTokenLifespan:      time.Minute,
-						RefreshTokenScopes:       []string{"offline"},
-					}
-					h = oauth2.GenericCodeTokenEndpointHandler{
-						AccessRequestValidator: &DeviceAccessRequestValidator{},
-						CodeHandler: &DeviceCodeHandler{
-							DeviceRateLimitStrategy: strategy,
-							DeviceCodeStrategy:      strategy,
-						},
-						SessionHandler: &DeviceSessionHandler{
-							DeviceCodeStorage: store,
-						},
-						AccessTokenStrategy:    strategy.CoreStrategy,
-						RefreshTokenStrategy:   strategy.CoreStrategy,
-						Config:                 config,
-						CoreStorage:            store,
-						TokenRevocationStorage: store,
-					}
-
-					if c.setup != nil {
-						c.setup(t, c.areq, config)
-					}
-
-					aresp := fosite.NewAccessResponse()
-					err := h.PopulateTokenEndpointResponse(context.TODO(), c.areq, aresp)
-
-					if c.expectErr != nil {
-						require.EqualError(t, err, c.expectErr.Error(), "%+v", err)
-					} else {
-						require.NoError(t, err, "%+v", err)
-					}
-
-					if c.check != nil {
-						c.check(t, aresp)
-					}
-				})
-			}
-		})
-	}
-}
-
 func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 	for k, strategy := range map[string]struct {
 		oauth2.CoreStrategy
@@ -285,7 +73,8 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 					DeviceAndUserCodeLifespan: time.Minute,
 				},
 			}
-			for i, c := range []struct {
+
+			testCases := []struct {
 				description string
 				areq        *fosite.AccessRequest
 				authreq     *fosite.DeviceRequest
@@ -454,22 +243,239 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 						require.NoError(t, store.CreateDeviceCodeSession(context.TODO(), signature, authreq))
 					},
 				},
-			} {
-				t.Run(fmt.Sprintf("case=%d/description=%s", i, c.description), func(t *testing.T) {
-					if c.setup != nil {
-						c.setup(t, c.areq, c.authreq)
+			}
+
+			for i, testCase := range testCases {
+				t.Run(fmt.Sprintf("case=%d/description=%s", i, testCase.description), func(t *testing.T) {
+					if testCase.setup != nil {
+						testCase.setup(t, testCase.areq, testCase.authreq)
 					}
 
-					t.Logf("Processing %+v", c.areq.Client)
+					t.Logf("Processing %+v", testCase.areq.Client)
 
-					err := h.HandleTokenEndpointRequest(context.Background(), c.areq)
-					if c.expectErr != nil {
-						require.EqualError(t, err, c.expectErr.Error(), "%+v", err)
+					err := h.HandleTokenEndpointRequest(context.Background(), testCase.areq)
+					if testCase.expectErr != nil {
+						require.EqualError(t, err, testCase.expectErr.Error(), "%+v", err)
 					} else {
 						require.NoError(t, err, "%+v", err)
-						if c.check != nil {
-							c.check(t, c.areq, c.authreq)
+						if testCase.check != nil {
+							testCase.check(t, testCase.areq, testCase.authreq)
 						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
+	for k, strategy := range map[string]struct {
+		oauth2.CoreStrategy
+		RFC8628CodeStrategy
+	}{
+		"hmac": {&hmacshaStrategy, &RFC8628HMACSHAStrategy},
+	} {
+		t.Run("strategy="+k, func(t *testing.T) {
+			store := storage.NewMemoryStore()
+
+			var h oauth2.GenericCodeTokenEndpointHandler
+
+			testCases := []struct {
+				areq        *fosite.AccessRequest
+				description string
+				setup       func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config)
+				check       func(t *testing.T, aresp *fosite.AccessResponse)
+				expectErr   error
+			}{
+				{
+					description: "should fail because not responsible",
+					areq: &fosite.AccessRequest{
+						GrantTypes: fosite.Arguments{"123"},
+					},
+					expectErr: fosite.ErrUnknownRequest,
+				},
+				{
+					description: "should fail because device code cannot be retrieved",
+					areq: &fosite.AccessRequest{
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+						Request: fosite.Request{
+							Form: url.Values{},
+							Client: &fosite.DefaultClient{
+								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+							},
+							Session:     &DefaultDeviceFlowSession{},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
+						code, _, err := strategy.GenerateDeviceCode(context.TODO())
+						require.NoError(t, err)
+						areq.Form.Set("device_code", code)
+					},
+					expectErr: fosite.ErrServerError,
+				},
+				{
+					description: "should fail because device code is expired",
+					areq: &fosite.AccessRequest{
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+						Request: fosite.Request{
+							Form: url.Values{},
+							Client: &fosite.DefaultClient{
+								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+							},
+							Session: &DefaultDeviceFlowSession{
+								ExpiresAt: map[fosite.TokenType]time.Time{
+									fosite.DeviceCode: time.Now().Add(-time.Hour).UTC(),
+								},
+								BrowserFlowCompleted: true,
+							},
+							RequestedAt: time.Now().Add(-2 * time.Hour).UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
+						code, signature, err := strategy.GenerateDeviceCode(context.TODO())
+						require.NoError(t, err)
+						areq.Form.Add("device_code", code)
+
+						require.NoError(t, store.CreateDeviceCodeSession(context.Background(), signature, areq))
+					},
+					expectErr: fosite.ErrInvalidRequest,
+				},
+				{
+					description: "should pass with offline scope and refresh token",
+					areq: &fosite.AccessRequest{
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+						Request: fosite.Request{
+							Form: url.Values{},
+							Client: &fosite.DefaultClient{
+								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode), string(fosite.GrantTypeRefreshToken)},
+							},
+							GrantedScope: fosite.Arguments{"foo", "offline"},
+							Session: &DefaultDeviceFlowSession{
+								BrowserFlowCompleted: true,
+							},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
+						code, signature, err := strategy.GenerateDeviceCode(context.TODO())
+						require.NoError(t, err)
+						areq.Form.Add("device_code", code)
+
+						require.NoError(t, store.CreateDeviceCodeSession(context.TODO(), signature, areq))
+					},
+					check: func(t *testing.T, aresp *fosite.AccessResponse) {
+						assert.NotEmpty(t, aresp.AccessToken)
+						assert.Equal(t, "bearer", aresp.TokenType)
+						assert.NotEmpty(t, aresp.GetExtra("refresh_token"))
+						assert.NotEmpty(t, aresp.GetExtra("expires_in"))
+						assert.Equal(t, "foo offline", aresp.GetExtra("scope"))
+					},
+				},
+				{
+					description: "should pass with refresh token always provided",
+					areq: &fosite.AccessRequest{
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+						Request: fosite.Request{
+							Form: url.Values{},
+							Client: &fosite.DefaultClient{
+								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode), string(fosite.GrantTypeRefreshToken)},
+							},
+							GrantedScope: fosite.Arguments{"foo"},
+							Session: &DefaultDeviceFlowSession{
+								BrowserFlowCompleted: true,
+							},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
+						config.RefreshTokenScopes = []string{}
+						code, signature, err := strategy.GenerateDeviceCode(context.TODO())
+						require.NoError(t, err)
+						areq.Form.Add("device_code", code)
+
+						require.NoError(t, store.CreateDeviceCodeSession(context.TODO(), signature, areq))
+					},
+					check: func(t *testing.T, aresp *fosite.AccessResponse) {
+						assert.NotEmpty(t, aresp.AccessToken)
+						assert.Equal(t, "bearer", aresp.TokenType)
+						assert.NotEmpty(t, aresp.GetExtra("refresh_token"))
+						assert.NotEmpty(t, aresp.GetExtra("expires_in"))
+						assert.Equal(t, "foo", aresp.GetExtra("scope"))
+					},
+				},
+				{
+					description: "pass and response should not have refresh token",
+					areq: &fosite.AccessRequest{
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+						Request: fosite.Request{
+							Form: url.Values{},
+							Client: &fosite.DefaultClient{
+								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+							},
+							GrantedScope: fosite.Arguments{"foo"},
+							Session: &DefaultDeviceFlowSession{
+								BrowserFlowCompleted: true,
+							},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
+						code, signature, err := strategy.GenerateDeviceCode(context.TODO())
+						require.NoError(t, err)
+						areq.Form.Add("device_code", code)
+
+						require.NoError(t, store.CreateDeviceCodeSession(context.TODO(), signature, areq))
+					},
+					check: func(t *testing.T, aresp *fosite.AccessResponse) {
+						assert.NotEmpty(t, aresp.AccessToken)
+						assert.Equal(t, "bearer", aresp.TokenType)
+						assert.Empty(t, aresp.GetExtra("refresh_token"))
+						assert.NotEmpty(t, aresp.GetExtra("expires_in"))
+						assert.Equal(t, "foo", aresp.GetExtra("scope"))
+					},
+				},
+			}
+
+			for _, testCase := range testCases {
+				t.Run("case="+testCase.description, func(t *testing.T) {
+					config := &fosite.Config{
+						ScopeStrategy:            fosite.HierarchicScopeStrategy,
+						AudienceMatchingStrategy: fosite.DefaultAudienceMatchingStrategy,
+						AccessTokenLifespan:      time.Minute,
+						RefreshTokenScopes:       []string{"offline"},
+					}
+					h = oauth2.GenericCodeTokenEndpointHandler{
+						AccessRequestValidator: &DeviceAccessRequestValidator{},
+						CodeHandler: &DeviceCodeHandler{
+							DeviceRateLimitStrategy: strategy,
+							DeviceCodeStrategy:      strategy,
+						},
+						SessionHandler: &DeviceSessionHandler{
+							DeviceCodeStorage: store,
+						},
+						AccessTokenStrategy:    strategy.CoreStrategy,
+						RefreshTokenStrategy:   strategy.CoreStrategy,
+						Config:                 config,
+						CoreStorage:            store,
+						TokenRevocationStorage: store,
+					}
+
+					if testCase.setup != nil {
+						testCase.setup(t, testCase.areq, config)
+					}
+
+					aresp := fosite.NewAccessResponse()
+					err := h.PopulateTokenEndpointResponse(context.TODO(), testCase.areq, aresp)
+
+					if testCase.expectErr != nil {
+						require.EqualError(t, err, testCase.expectErr.Error(), "%+v", err)
+					} else {
+						require.NoError(t, err, "%+v", err)
+					}
+
+					if testCase.check != nil {
+						testCase.check(t, aresp)
 					}
 				})
 			}
@@ -514,7 +520,7 @@ func TestDeviceUserCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 		DeviceCodeStorage
 	}
 
-	for _, testCase := range []struct {
+	testCases := []struct {
 		description string
 		setup       func()
 		expectError error
@@ -688,7 +694,9 @@ func TestDeviceUserCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 			},
 			expectError: fosite.ErrServerError,
 		},
-	} {
+	}
+
+	for _, testCase := range testCases {
 		t.Run(fmt.Sprintf("scenario=%s", testCase.description), func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()


### PR DESCRIPTION
This pull request tries to

- handle the authorization pending error in the device flow
- fix the bug when validating the auth/device code expiration
- re-organize the test cases for access token request handling. Make it easier to read.