### PR TITLE
fix: fix oauth2 core storage interface and device flow session type assertion

### DIFF
--- a/handler/oauth2/flow_authorize_code_token_test.go
+++ b/handler/oauth2/flow_authorize_code_token_test.go
@@ -31,8 +31,8 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 			var h GenericCodeTokenEndpointHandler
 
 			testCases := []struct {
-				areq        *fosite.AccessRequest
 				description string
+				areq        *fosite.AccessRequest
 				setup       func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config)
 				check       func(t *testing.T, aresp *fosite.AccessResponse)
 				expectErr   error

--- a/handler/oauth2/storage.go
+++ b/handler/oauth2/storage.go
@@ -10,6 +10,7 @@ import (
 )
 
 type CoreStorage interface {
+	AuthorizeCodeStorage
 	AccessTokenStorage
 	RefreshTokenStorage
 }

--- a/handler/rfc8628/strategy_hmacsha.go
+++ b/handler/rfc8628/strategy_hmacsha.go
@@ -22,8 +22,8 @@ import (
 
 // DeviceFlowSession is a fosite.Session container specific for the device flow.
 type DeviceFlowSession interface {
-	// BrowserFlowCompleted returns the flag indicating whether user has completed the browser flow or not.
-	BrowserFlowCompleted() bool
+	// GetBrowserFlowCompleted returns the flag indicating whether user has completed the browser flow or not.
+	GetBrowserFlowCompleted() bool
 
 	// SetBrowserFlowCompleted allows client to mark user has completed the browser flow.
 	SetBrowserFlowCompleted(flag bool)

--- a/handler/rfc8628/token_handler.go
+++ b/handler/rfc8628/token_handler.go
@@ -67,7 +67,7 @@ func (s DeviceSessionHandler) Session(ctx context.Context, requester fosite.Acce
 		return nil, errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebug(err.Error()))
 	}
 
-	session, ok := req.GetSession().(*DefaultDeviceFlowSession)
+	session, ok := req.GetSession().(DeviceFlowSession)
 	if !ok {
 		return nil, fosite.ErrServerError.WithHint("Wrong authorization request session.")
 	}


### PR DESCRIPTION
This pull request tries to fix the following:

- Missing embedded interface for oauth2 core storage
- Type assertion in handling the authorization pending error