### PR TITLE
fix: rate limiting

### DIFF
--- a/handler/oauth2/flow_authorize_code_token.go
+++ b/handler/oauth2/flow_authorize_code_token.go
@@ -24,6 +24,10 @@ func (c AuthorizeCodeHandler) Code(ctx context.Context, requester fosite.AccessR
 }
 
 func (c AuthorizeCodeHandler) ValidateCode(ctx context.Context, requester fosite.Requester, code string) error {
+	return nil
+}
+
+func (c AuthorizeCodeHandler) ValidateCodeSession(ctx context.Context, requester fosite.Requester, code string) error {
 	return c.AuthorizeCodeStrategy.ValidateAuthorizeCode(ctx, requester, code)
 }
 

--- a/handler/oauth2/flow_authorize_code_token_test.go
+++ b/handler/oauth2/flow_authorize_code_token_test.go
@@ -65,28 +65,6 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 					expectErr: fosite.ErrServerError,
 				},
 				{
-					description: "should fail because authorization code is expired",
-					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"authorization_code"},
-						Request: fosite.Request{
-							Form: url.Values{"code": []string{"foo.bar"}},
-							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{"authorization_code"},
-							},
-							Session: &fosite.DefaultSession{
-								ExpiresAt: map[fosite.TokenType]time.Time{
-									fosite.AuthorizeCode: time.Now().Add(-time.Hour).UTC(),
-								},
-							},
-							RequestedAt: time.Now().Add(-2 * time.Hour).UTC(),
-						},
-					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
-						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), "bar", areq))
-					},
-					expectErr: fosite.ErrInvalidRequest,
-				},
-				{
 					description: "should pass with offline scope and refresh token",
 					areq: &fosite.AccessRequest{
 						GrantTypes: fosite.Arguments{"authorization_code"},

--- a/handler/rfc8628/token_handler.go
+++ b/handler/rfc8628/token_handler.go
@@ -22,15 +22,6 @@ type DeviceCodeHandler struct {
 func (c DeviceCodeHandler) Code(ctx context.Context, requester fosite.AccessRequester) (code string, signature string, err error) {
 	code = requester.GetRequestForm().Get("device_code")
 
-	shouldRateLimit, err := c.DeviceRateLimitStrategy.ShouldRateLimit(ctx, code)
-	// TODO(nsklikas) : should we error out or just silently log it?
-	if err != nil {
-		return "", "", err
-	}
-	if shouldRateLimit {
-		return "", "", errorsx.WithStack(fosite.ErrPollingRateLimited)
-	}
-
 	signature, err = c.DeviceCodeStrategy.DeviceCodeSignature(ctx, code)
 	if err != nil {
 		return "", "", errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebug(err.Error()))
@@ -40,6 +31,18 @@ func (c DeviceCodeHandler) Code(ctx context.Context, requester fosite.AccessRequ
 }
 
 func (c DeviceCodeHandler) ValidateCode(ctx context.Context, requester fosite.Requester, code string) error {
+	shouldRateLimit, err := c.DeviceRateLimitStrategy.ShouldRateLimit(ctx, code)
+	// TODO(nsklikas) : should we error out or just silently log it?
+	if err != nil {
+		return err
+	}
+	if shouldRateLimit {
+		return errorsx.WithStack(fosite.ErrPollingRateLimited)
+	}
+	return nil
+}
+
+func (c DeviceCodeHandler) ValidateCodeSession(ctx context.Context, requester fosite.Requester, code string) error {
 	return c.DeviceCodeStrategy.ValidateDeviceCode(ctx, requester, code)
 }
 


### PR DESCRIPTION
- Fix rate limiting logic
- Separate code validation into 2 steps: `ValidateCode` and `ValidateCodeSession`. The first will be used to perform quick checks before we fetch the code from the database and the latter will be used to validate the code session that we fetched from the database. `ValidateCodeSession` is called when parsing the request and when constructing the response. This feels like an overkill but I didn't want to introduce any breaking changes.