### PR TITLE
fix: fix the refresh token issue

### DIFF
--- a/handler/oauth2/flow_authorize_code_token_test.go
+++ b/handler/oauth2/flow_authorize_code_token_test.go
@@ -39,10 +39,10 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 				{
 					description: "should fail because not responsible for handling the request",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeImplicit)},
+						GrantTypes: fosite.Arguments{"implicit"},
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: fosite.Arguments{"authorization_code"},
 							},
 							Session:     &fosite.DefaultSession{},
 							RequestedAt: time.Now().UTC(),
@@ -53,11 +53,11 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 				{
 					description: "should fail because authorization code cannot be retrieved",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: fosite.Arguments{"authorization_code"},
 							},
 							Session:     &fosite.DefaultSession{},
 							RequestedAt: time.Now().UTC(),
@@ -73,12 +73,12 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 				{
 					description: "should pass with offline scope and refresh token grant type",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode), string(fosite.GrantTypeRefreshToken)},
+								GrantTypes: fosite.Arguments{"authorization_code", "refresh_token"},
 							},
 							Session:     &fosite.DefaultSession{},
 							RequestedAt: time.Now().UTC(),
@@ -88,7 +88,7 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: []string{"authorization_code"},
 							},
 							RequestedScope: fosite.Arguments{"foo", "bar", "offline"},
 							GrantedScope:   fosite.Arguments{"foo", "offline"},
@@ -114,12 +114,12 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 				{
 					description: "should pass with refresh token grant type",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode), string(fosite.GrantTypeRefreshToken)},
+								GrantTypes: fosite.Arguments{"authorization_code", "refresh_token"},
 							},
 							Session:     &fosite.DefaultSession{},
 							RequestedAt: time.Now().UTC(),
@@ -129,7 +129,7 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: []string{"authorization_code"},
 							},
 							RequestedScope: fosite.Arguments{"foo", "bar"},
 							GrantedScope:   fosite.Arguments{"foo"},
@@ -156,7 +156,7 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 				{
 					description: "pass and response should not have refresh token",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
@@ -171,7 +171,7 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeDeviceCode)},
+								GrantTypes: []string{"authorization_code"},
 							},
 							RequestedScope: fosite.Arguments{"foo", "bar"},
 							GrantedScope:   fosite.Arguments{"foo"},
@@ -274,11 +274,11 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should fail because not responsible for handling the request",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeImplicit)},
+						GrantTypes: fosite.Arguments{"implicit"},
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: []string{"authorization_code"},
 							},
 							Form:        url.Values{"redirect_uri": []string{"request-redir"}},
 							Session:     &fosite.DefaultSession{},
@@ -306,11 +306,11 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should fail because authorization code cannot be retrieved",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: []string{"authorization_code"},
 							},
 							Form:        url.Values{"redirect_uri": []string{"request-redir"}},
 							Session:     &fosite.DefaultSession{},
@@ -327,7 +327,7 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should fail because authorization code is expired",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Form: url.Values{
 								"code":         {"foo.bar"},
@@ -335,7 +335,7 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 							},
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: []string{"authorization_code"},
 							},
 							Session:     &fosite.DefaultSession{},
 							RequestedAt: time.Now().UTC(),
@@ -345,7 +345,7 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: []string{"authorization_code"},
 							},
 							Form:           url.Values{"redirect_uri": []string{"request-redir"}},
 							RequestedScope: fosite.Arguments{"foo"},
@@ -370,11 +370,11 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should fail because client mismatch",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: []string{"authorization_code"},
 							},
 							Form:        url.Values{"redirect_uri": []string{"request-redir"}},
 							Session:     &fosite.DefaultSession{},
@@ -385,7 +385,7 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "bar",
-								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: []string{"authorization_code"},
 							},
 							Form:           url.Values{"redirect_uri": []string{"request-redir"}},
 							RequestedScope: fosite.Arguments{"foo"},
@@ -409,11 +409,11 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should fail because redirect uri was set during /authorize call, but not in /token call",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: []string{"authorization_code"},
 							},
 							Form:        url.Values{},
 							Session:     &fosite.DefaultSession{},
@@ -424,7 +424,7 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: []string{"authorization_code"},
 							},
 							Form:           url.Values{"redirect_uri": []string{"request-redir"}},
 							RequestedScope: fosite.Arguments{"foo"},
@@ -448,11 +448,11 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should pass",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: []string{"authorization_code"},
 							},
 							Form:        url.Values{"redirect_uri": []string{"request-redir"}},
 							Session:     &fosite.DefaultSession{},
@@ -463,7 +463,7 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: []string{"authorization_code"},
 							},
 							Form:           url.Values{"redirect_uri": []string{"request-redir"}},
 							RequestedScope: fosite.Arguments{"foo"},
@@ -483,12 +483,12 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should fail because code has been used already",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Form: url.Values{"redirect_uri": []string{"request-redir"}},
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: fosite.Arguments{"authorization_code"},
 							},
 							Session:     &fosite.DefaultSession{},
 							RequestedAt: time.Now().UTC(),
@@ -498,7 +498,7 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+								GrantTypes: []string{"authorization_code"},
 							},
 							Form:           url.Values{"redirect_uri": []string{"request-redir"}},
 							RequestedScope: fosite.Arguments{"foo"},
@@ -552,7 +552,7 @@ func TestAuthorizeCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 		Request: fosite.Request{
 			Client: &fosite.DefaultClient{
 				ID:         "foo",
-				GrantTypes: []string{string(fosite.GrantTypeDeviceCode)},
+				GrantTypes: []string{"authorization_code"},
 			},
 			RequestedScope: fosite.Arguments{"foo", "offline"},
 			GrantedScope:   fosite.Arguments{"foo", "offline"},
@@ -562,10 +562,10 @@ func TestAuthorizeCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 	}
 
 	areq := &fosite.AccessRequest{
-		GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+		GrantTypes: fosite.Arguments{"authorization_code"},
 		Request: fosite.Request{
 			Client: &fosite.DefaultClient{
-				GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode), string(fosite.GrantTypeRefreshToken)},
+				GrantTypes: fosite.Arguments{"authorization_code", "refresh_token"},
 			},
 			Session:     &fosite.DefaultSession{},
 			RequestedAt: time.Now().UTC(),

--- a/handler/oauth2/flow_authorize_code_token_test.go
+++ b/handler/oauth2/flow_authorize_code_token_test.go
@@ -28,36 +28,42 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 		t.Run("strategy="+k, func(t *testing.T) {
 			store := storage.NewMemoryStore()
 
-			var h GenericCodeTokenEndpointHandler
-
 			testCases := []struct {
 				description string
 				areq        *fosite.AccessRequest
-				setup       func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config)
+				authreq     *fosite.AuthorizeRequest
+				setup       func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest, config *fosite.Config)
 				check       func(t *testing.T, aresp *fosite.AccessResponse)
 				expectErr   error
 			}{
 				{
-					description: "should fail because not responsible",
+					description: "should fail because not responsible for handling the request",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"123"},
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeImplicit)},
+						Request: fosite.Request{
+							Client: &fosite.DefaultClient{
+								GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+							},
+							Session:     &fosite.DefaultSession{},
+							RequestedAt: time.Now().UTC(),
+						},
 					},
 					expectErr: fosite.ErrUnknownRequest,
 				},
 				{
 					description: "should fail because authorization code cannot be retrieved",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"authorization_code"},
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{"authorization_code"},
+								GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
 							},
 							Session:     &fosite.DefaultSession{},
 							RequestedAt: time.Now().UTC(),
 						},
 					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
+					setup: func(t *testing.T, areq *fosite.AccessRequest, _ *fosite.AuthorizeRequest, _ *fosite.Config) {
 						code, _, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
 						require.NoError(t, err)
 						areq.Form.Set("code", code)
@@ -65,25 +71,37 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 					expectErr: fosite.ErrServerError,
 				},
 				{
-					description: "should pass with offline scope and refresh token",
+					description: "should pass with offline scope and refresh token grant type",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"authorization_code"},
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{"authorization_code", "refresh_token"},
+								ID:         "foo",
+								GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode), string(fosite.GrantTypeRefreshToken)},
 							},
-							GrantedScope: fosite.Arguments{"foo", "offline"},
-							Session:      &fosite.DefaultSession{},
-							RequestedAt:  time.Now().UTC(),
+							Session:     &fosite.DefaultSession{},
+							RequestedAt: time.Now().UTC(),
 						},
 					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
+					authreq: &fosite.AuthorizeRequest{
+						Request: fosite.Request{
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+							},
+							RequestedScope: fosite.Arguments{"foo", "bar", "offline"},
+							GrantedScope:   fosite.Arguments{"foo", "offline"},
+							Session:        &fosite.DefaultSession{},
+							RequestedAt:    time.Now().UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest, _ *fosite.Config) {
 						code, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
 						require.NoError(t, err)
-						areq.Form.Add("code", code)
+						areq.Form.Set("code", code)
 
-						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, areq))
+						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
 					},
 					check: func(t *testing.T, aresp *fosite.AccessResponse) {
 						assert.NotEmpty(t, aresp.AccessToken)
@@ -94,26 +112,38 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 					},
 				},
 				{
-					description: "should pass with refresh token always provided",
+					description: "should pass with refresh token grant type",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"authorization_code"},
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{"authorization_code", "refresh_token"},
+								ID:         "foo",
+								GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode), string(fosite.GrantTypeRefreshToken)},
 							},
-							GrantedScope: fosite.Arguments{"foo"},
-							Session:      &fosite.DefaultSession{},
-							RequestedAt:  time.Now().UTC(),
+							Session:     &fosite.DefaultSession{},
+							RequestedAt: time.Now().UTC(),
 						},
 					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
+					authreq: &fosite.AuthorizeRequest{
+						Request: fosite.Request{
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+							},
+							RequestedScope: fosite.Arguments{"foo", "bar"},
+							GrantedScope:   fosite.Arguments{"foo"},
+							Session:        &fosite.DefaultSession{},
+							RequestedAt:    time.Now().UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest, config *fosite.Config) {
 						config.RefreshTokenScopes = []string{}
 						code, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
 						require.NoError(t, err)
-						areq.Form.Add("code", code)
+						areq.Form.Set("code", code)
 
-						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, areq))
+						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
 					},
 					check: func(t *testing.T, aresp *fosite.AccessResponse) {
 						assert.NotEmpty(t, aresp.AccessToken)
@@ -126,23 +156,35 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 				{
 					description: "pass and response should not have refresh token",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"authorization_code"},
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
+								ID:         "foo",
 								GrantTypes: fosite.Arguments{"authorization_code"},
 							},
-							GrantedScope: fosite.Arguments{"foo"},
-							Session:      &fosite.DefaultSession{},
-							RequestedAt:  time.Now().UTC(),
+							Session:     &fosite.DefaultSession{},
+							RequestedAt: time.Now().UTC(),
 						},
 					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
+					authreq: &fosite.AuthorizeRequest{
+						Request: fosite.Request{
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeDeviceCode)},
+							},
+							RequestedScope: fosite.Arguments{"foo", "bar"},
+							GrantedScope:   fosite.Arguments{"foo"},
+							Session:        &fosite.DefaultSession{},
+							RequestedAt:    time.Now().UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest, _ *fosite.Config) {
 						code, sig, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
 						require.NoError(t, err)
-						areq.Form.Add("code", code)
+						areq.Form.Set("code", code)
 
-						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), sig, areq))
+						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), sig, authreq))
 					},
 					check: func(t *testing.T, aresp *fosite.AccessResponse) {
 						assert.NotEmpty(t, aresp.AccessToken)
@@ -162,7 +204,7 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 						AccessTokenLifespan:      time.Minute,
 						RefreshTokenScopes:       []string{"offline"},
 					}
-					h = GenericCodeTokenEndpointHandler{
+					h := GenericCodeTokenEndpointHandler{
 						AccessRequestValidator: &AuthorizeExplicitGrantAccessRequestValidator{},
 						CodeHandler: &AuthorizeCodeHandler{
 							AuthorizeCodeStrategy: strategy,
@@ -177,7 +219,7 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 					}
 
 					if testCase.setup != nil {
-						testCase.setup(t, testCase.areq, config)
+						testCase.setup(t, testCase.areq, testCase.authreq, config)
 					}
 
 					aresp := fosite.NewAccessResponse()
@@ -230,9 +272,18 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 				expectErr   error
 			}{
 				{
-					description: "should fail because not responsible",
+					description: "should fail because not responsible for handling the request",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"12345678"},
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeImplicit)},
+						Request: fosite.Request{
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+							},
+							Form:        url.Values{"redirect_uri": []string{"request-redir"}},
+							Session:     &fosite.DefaultSession{},
+							RequestedAt: time.Now().UTC(),
+						},
 					},
 					expectErr: fosite.ErrUnknownRequest,
 				},
@@ -241,7 +292,11 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 					areq: &fosite.AccessRequest{
 						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{""}},
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{""},
+							},
+							Form:        url.Values{"redirect_uri": []string{"request-redir"}},
 							Session:     &fosite.DefaultSession{},
 							RequestedAt: time.Now().UTC(),
 						},
@@ -251,34 +306,50 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should fail because authorization code cannot be retrieved",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"authorization_code"},
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
 						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{GrantTypes: []string{"authorization_code"}},
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+							},
+							Form:        url.Values{"redirect_uri": []string{"request-redir"}},
 							Session:     &fosite.DefaultSession{},
 							RequestedAt: time.Now().UTC(),
 						},
 					},
 					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
-						token, _, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
+						code, _, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
 						require.NoError(t, err)
-						areq.Form = url.Values{"code": {token}}
+						areq.Form.Set("code", code)
 					},
 					expectErr: fosite.ErrInvalidGrant,
 				},
 				{
 					description: "should fail because authorization code is expired",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"authorization_code"},
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
 						Request: fosite.Request{
-							Form:        url.Values{"code": {"foo.bar"}},
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"authorization_code"}},
+							Form: url.Values{
+								"code":         {"foo.bar"},
+								"redirect_uri": []string{"request-redir"},
+							},
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+							},
 							Session:     &fosite.DefaultSession{},
 							RequestedAt: time.Now().UTC(),
 						},
 					},
 					authreq: &fosite.AuthorizeRequest{
 						Request: fosite.Request{
-							Client: &fosite.DefaultClient{ID: "foo"},
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+							},
+							Form:           url.Values{"redirect_uri": []string{"request-redir"}},
+							RequestedScope: fosite.Arguments{"foo"},
+							GrantedScope:   fosite.Arguments{"foo"},
 							Session: &fosite.DefaultSession{
 								ExpiresAt: map[fosite.TokenType]time.Time{
 									fosite.AuthorizeCode: time.Now().Add(-time.Hour).UTC(),
@@ -288,9 +359,9 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 						},
 					},
 					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
-						token, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
+						code, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
 						require.NoError(t, err)
-						areq.Form = url.Values{"code": {token}}
+						areq.Form.Set("code", code)
 
 						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
 					},
@@ -299,16 +370,26 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should fail because client mismatch",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"authorization_code"},
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
 						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"authorization_code"}},
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+							},
+							Form:        url.Values{"redirect_uri": []string{"request-redir"}},
 							Session:     &fosite.DefaultSession{},
 							RequestedAt: time.Now().UTC(),
 						},
 					},
 					authreq: &fosite.AuthorizeRequest{
 						Request: fosite.Request{
-							Client: &fosite.DefaultClient{ID: "bar"},
+							Client: &fosite.DefaultClient{
+								ID:         "bar",
+								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+							},
+							Form:           url.Values{"redirect_uri": []string{"request-redir"}},
+							RequestedScope: fosite.Arguments{"foo"},
+							GrantedScope:   fosite.Arguments{"foo"},
 							Session: &fosite.DefaultSession{
 								ExpiresAt: map[fosite.TokenType]time.Time{
 									fosite.AuthorizeCode: time.Now().Add(time.Hour).UTC(),
@@ -317,9 +398,9 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 						},
 					},
 					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
-						token, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
+						code, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
 						require.NoError(t, err)
-						areq.Form = url.Values{"code": {token}}
+						areq.Form.Set("code", code)
 
 						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
 					},
@@ -328,17 +409,26 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should fail because redirect uri was set during /authorize call, but not in /token call",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"authorization_code"},
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
 						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"authorization_code"}},
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+							},
+							Form:        url.Values{},
 							Session:     &fosite.DefaultSession{},
 							RequestedAt: time.Now().UTC(),
 						},
 					},
 					authreq: &fosite.AuthorizeRequest{
 						Request: fosite.Request{
-							Client: &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"authorization_code"}},
-							Form:   url.Values{"redirect_uri": []string{"request-redir"}},
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+							},
+							Form:           url.Values{"redirect_uri": []string{"request-redir"}},
+							RequestedScope: fosite.Arguments{"foo"},
+							GrantedScope:   fosite.Arguments{"foo"},
 							Session: &fosite.DefaultSession{
 								ExpiresAt: map[fosite.TokenType]time.Time{
 									fosite.AuthorizeCode: time.Now().Add(time.Hour).UTC(),
@@ -347,9 +437,9 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 						},
 					},
 					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
-						token, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
+						code, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
 						require.NoError(t, err)
-						areq.Form = url.Values{"code": {token}}
+						areq.Form.Set("code", code)
 
 						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
 					},
@@ -358,9 +448,12 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should pass",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"authorization_code"},
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
 						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"authorization_code"}},
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+							},
 							Form:        url.Values{"redirect_uri": []string{"request-redir"}},
 							Session:     &fosite.DefaultSession{},
 							RequestedAt: time.Now().UTC(),
@@ -368,41 +461,56 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 					},
 					authreq: &fosite.AuthorizeRequest{
 						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"authorization_code"}},
-							Session:     &fosite.DefaultSession{},
-							RequestedAt: time.Now().UTC(),
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+							},
+							Form:           url.Values{"redirect_uri": []string{"request-redir"}},
+							RequestedScope: fosite.Arguments{"foo"},
+							GrantedScope:   fosite.Arguments{"foo"},
+							Session:        &fosite.DefaultSession{},
+							RequestedAt:    time.Now().UTC(),
 						},
 					},
 					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
-						token, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
+						code, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
 						require.NoError(t, err)
+						areq.Form.Set("code", code)
 
-						areq.Form = url.Values{"code": {token}}
 						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
 					},
 				},
 				{
 					description: "should fail because code has been used already",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"authorization_code"},
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
 						Request: fosite.Request{
-							Form:        url.Values{},
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: fosite.Arguments{"authorization_code"}},
+							Form: url.Values{"redirect_uri": []string{"request-redir"}},
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+							},
 							Session:     &fosite.DefaultSession{},
 							RequestedAt: time.Now().UTC(),
 						},
 					},
 					authreq: &fosite.AuthorizeRequest{
 						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"authorization_code"}},
-							Session:     &fosite.DefaultSession{},
-							RequestedAt: time.Now().UTC(),
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+							},
+							Form:           url.Values{"redirect_uri": []string{"request-redir"}},
+							RequestedScope: fosite.Arguments{"foo"},
+							GrantedScope:   fosite.Arguments{"foo"},
+							Session:        &fosite.DefaultSession{},
+							RequestedAt:    time.Now().UTC(),
 						},
 					},
 					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.AuthorizeRequest) {
 						code, signature, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
 						require.NoError(t, err)
-						areq.Form.Add("code", code)
+						areq.Form.Set("code", code)
 
 						require.NoError(t, store.CreateAuthorizeCodeSession(context.Background(), signature, authreq))
 						require.NoError(t, store.InvalidateAuthorizeCodeSession(context.Background(), signature))
@@ -439,22 +547,36 @@ func TestAuthorizeCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 	var mockCoreStore *internal.MockCoreStorage
 	var mockAuthorizeStore *internal.MockAuthorizeCodeStorage
 	strategy := hmacshaStrategy
-	request := &fosite.AccessRequest{
-		GrantTypes: fosite.Arguments{"authorization_code"},
+
+	authreq := &fosite.AuthorizeRequest{
 		Request: fosite.Request{
 			Client: &fosite.DefaultClient{
-				GrantTypes: fosite.Arguments{"authorization_code", "refresh_token"},
+				ID:         "foo",
+				GrantTypes: []string{string(fosite.GrantTypeDeviceCode)},
 			},
-			GrantedScope: fosite.Arguments{"offline"},
-			Session:      &fosite.DefaultSession{},
-			RequestedAt:  time.Now().UTC(),
+			RequestedScope: fosite.Arguments{"foo", "offline"},
+			GrantedScope:   fosite.Arguments{"foo", "offline"},
+			Session:        &fosite.DefaultSession{},
+			RequestedAt:    time.Now().UTC(),
 		},
 	}
-	token, _, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
-	require.NoError(t, err)
-	request.Form = url.Values{"code": {token}}
-	response := fosite.NewAccessResponse()
+
+	areq := &fosite.AccessRequest{
+		GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+		Request: fosite.Request{
+			Client: &fosite.DefaultClient{
+				GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode), string(fosite.GrantTypeRefreshToken)},
+			},
+			Session:     &fosite.DefaultSession{},
+			RequestedAt: time.Now().UTC(),
+		},
+	}
+	aresp := fosite.NewAccessResponse()
 	propagatedContext := context.Background()
+
+	code, _, err := strategy.GenerateAuthorizeCode(context.Background(), nil)
+	require.NoError(t, err)
+	areq.Form = url.Values{"code": {code}}
 
 	// some storage implementation that has support for transactions, notice the embedded type `storage.Transactional`
 	type transactionalStore struct {
@@ -478,7 +600,7 @@ func TestAuthorizeCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 				mockAuthorizeStore.
 					EXPECT().
 					GetAuthorizeCodeSession(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(request, nil).
+					Return(authreq, nil).
 					Times(1)
 				mockTransactional.
 					EXPECT().
@@ -512,7 +634,7 @@ func TestAuthorizeCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 				mockAuthorizeStore.
 					EXPECT().
 					GetAuthorizeCodeSession(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(request, nil).
+					Return(authreq, nil).
 					Times(1)
 				mockTransactional.
 					EXPECT().
@@ -537,7 +659,7 @@ func TestAuthorizeCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 				mockAuthorizeStore.
 					EXPECT().
 					GetAuthorizeCodeSession(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(request, nil).
+					Return(authreq, nil).
 					Times(1)
 				mockTransactional.
 					EXPECT().
@@ -567,7 +689,7 @@ func TestAuthorizeCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 				mockAuthorizeStore.
 					EXPECT().
 					GetAuthorizeCodeSession(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(request, nil).
+					Return(authreq, nil).
 					Times(1)
 				mockTransactional.
 					EXPECT().
@@ -582,7 +704,7 @@ func TestAuthorizeCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 				mockAuthorizeStore.
 					EXPECT().
 					GetAuthorizeCodeSession(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(request, nil).
+					Return(authreq, nil).
 					Times(1)
 				mockTransactional.
 					EXPECT().
@@ -607,7 +729,7 @@ func TestAuthorizeCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 				mockAuthorizeStore.
 					EXPECT().
 					GetAuthorizeCodeSession(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(request, nil).
+					Return(authreq, nil).
 					Times(1)
 				mockTransactional.
 					EXPECT().
@@ -658,7 +780,7 @@ func TestAuthorizeCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 				AudienceMatchingStrategy: fosite.DefaultAudienceMatchingStrategy,
 				AuthorizeCodeLifespan:    time.Minute,
 			}
-			handler := GenericCodeTokenEndpointHandler{
+			h := GenericCodeTokenEndpointHandler{
 				AccessRequestValidator: &AuthorizeExplicitGrantAccessRequestValidator{},
 				CodeHandler: &AuthorizeCodeHandler{
 					AuthorizeCodeStrategy: &strategy,
@@ -678,7 +800,7 @@ func TestAuthorizeCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 				Config:               config,
 			}
 
-			if err := handler.PopulateTokenEndpointResponse(propagatedContext, request, response); testCase.expectError != nil {
+			if err := h.PopulateTokenEndpointResponse(propagatedContext, areq, aresp); testCase.expectError != nil {
 				assert.EqualError(t, err, testCase.expectError.Error())
 			}
 		})

--- a/handler/openid/flow_device_auth.go
+++ b/handler/openid/flow_device_auth.go
@@ -25,7 +25,7 @@ type OpenIDConnectDeviceHandler struct {
 }
 
 func (c *OpenIDConnectDeviceHandler) HandleDeviceEndpointRequest(ctx context.Context, dar fosite.DeviceRequester, resp fosite.DeviceResponder) error {
-	if !(dar.GetGrantedScopes().Has("openid")) {
+	if !(dar.GetRequestedScopes().Has("openid")) {
 		return nil
 	}
 

--- a/handler/openid/flow_device_auth.go
+++ b/handler/openid/flow_device_auth.go
@@ -33,7 +33,7 @@ func (c *OpenIDConnectDeviceHandler) HandleDeviceEndpointRequest(ctx context.Con
 		return nil
 	}
 
-	if len(resp.GetDeviceCode()) == 0 {
+	if resp.GetDeviceCode() == "" {
 		return errorsx.WithStack(fosite.ErrMisconfiguration.WithDebug("The device code has not been issued yet, indicating a broken code configuration."))
 	}
 

--- a/handler/openid/flow_device_auth_test.go
+++ b/handler/openid/flow_device_auth_test.go
@@ -78,7 +78,7 @@ func TestDeviceAuth_HandleDeviceEndpointRequest(t *testing.T) {
 			description: "should ignore because scope openid is not set",
 			authreq: &fosite.DeviceRequest{
 				Request: fosite.Request{
-					GrantedScope: fosite.Arguments{"email"},
+					RequestedScope: fosite.Arguments{"email"},
 				},
 			},
 		},
@@ -86,7 +86,7 @@ func TestDeviceAuth_HandleDeviceEndpointRequest(t *testing.T) {
 			description: "should ignore because client grant type is invalid",
 			authreq: &fosite.DeviceRequest{
 				Request: fosite.Request{
-					GrantedScope: fosite.Arguments{"openid", "email"},
+					RequestedScope: fosite.Arguments{"openid", "email"},
 					Client: &fosite.DefaultClient{
 						GrantTypes: []string{"authorization_code"},
 					},
@@ -97,8 +97,8 @@ func TestDeviceAuth_HandleDeviceEndpointRequest(t *testing.T) {
 			description: "should fail because device code is not issued",
 			authreq: &fosite.DeviceRequest{
 				Request: fosite.Request{
-					GrantedScope: fosite.Arguments{"openid", "email"},
-					Client:       client,
+					RequestedScope: fosite.Arguments{"openid", "email"},
+					Client:         client,
 				},
 			},
 			authresp:  &fosite.DeviceResponse{},
@@ -108,9 +108,9 @@ func TestDeviceAuth_HandleDeviceEndpointRequest(t *testing.T) {
 			description: "should fail because cannot create session",
 			authreq: &fosite.DeviceRequest{
 				Request: fosite.Request{
-					GrantedScope: fosite.Arguments{"openid", "email"},
-					Client:       client,
-					Session:      session,
+					RequestedScope: fosite.Arguments{"openid", "email"},
+					Client:         client,
+					Session:        session,
 				},
 			},
 			authresp: &fosite.DeviceResponse{
@@ -128,9 +128,9 @@ func TestDeviceAuth_HandleDeviceEndpointRequest(t *testing.T) {
 			description: "should pass",
 			authreq: &fosite.DeviceRequest{
 				Request: fosite.Request{
-					GrantedScope: fosite.Arguments{"openid", "email"},
-					Client:       client,
-					Session:      session,
+					RequestedScope: fosite.Arguments{"openid", "email"},
+					Client:         client,
+					Session:        session,
 				},
 			},
 			authresp: &fosite.DeviceResponse{

--- a/handler/openid/flow_device_auth_test.go
+++ b/handler/openid/flow_device_auth_test.go
@@ -64,7 +64,7 @@ func TestDeviceAuth_HandleDeviceEndpointRequest(t *testing.T) {
 
 	client := &fosite.DefaultClient{
 		ID:         "foo",
-		GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+		GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 	}
 
 	testCases := []struct {
@@ -88,7 +88,7 @@ func TestDeviceAuth_HandleDeviceEndpointRequest(t *testing.T) {
 				Request: fosite.Request{
 					GrantedScope: fosite.Arguments{"openid", "email"},
 					Client: &fosite.DefaultClient{
-						GrantTypes: []string{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: []string{"authorization_code"},
 					},
 				},
 			},

--- a/handler/openid/flow_device_token_test.go
+++ b/handler/openid/flow_device_token_test.go
@@ -81,7 +81,7 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 
 	client := &fosite.DefaultClient{
 		ID:         "foo",
-		GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+		GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 	}
 
 	testCases := []struct {
@@ -95,7 +95,7 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 		{
 			description: "should fail because the grant type is invalid",
 			areq: &fosite.AccessRequest{
-				GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+				GrantTypes: fosite.Arguments{"authorization_code"},
 				Request: fosite.Request{
 					Form:    url.Values{"device_code": []string{"device_code"}},
 					Session: session,
@@ -107,7 +107,7 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 		{
 			description: "should fail because session not found",
 			areq: &fosite.AccessRequest{
-				GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+				GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 				Request: fosite.Request{
 					Form:    url.Values{"device_code": []string{"device_code"}},
 					Session: session,
@@ -122,7 +122,7 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 		{
 			description: "should fail because session lookup fails",
 			areq: &fosite.AccessRequest{
-				GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+				GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 				Request: fosite.Request{
 					Form:    url.Values{"device_code": []string{"device_code"}},
 					Session: session,
@@ -136,7 +136,7 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 		{
 			description: "should fail because auth request grant scope is invalid",
 			areq: &fosite.AccessRequest{
-				GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+				GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 				Request: fosite.Request{
 					Form:    url.Values{"device_code": []string{"device_code"}},
 					Session: session,
@@ -156,10 +156,10 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 		{
 			description: "should fail because auth request's client grant type is invalid",
 			areq: &fosite.AccessRequest{
-				GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+				GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 				Request: fosite.Request{
 					Client: &fosite.DefaultClient{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 					},
 					Form:    url.Values{"device_code": []string{"device_code"}},
 					Session: session,
@@ -179,7 +179,7 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 		{
 			description: "should fail because auth request is missing session",
 			areq: &fosite.AccessRequest{
-				GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+				GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 				Request: fosite.Request{
 					Client:  client,
 					Form:    url.Values{"device_code": []string{"device_code"}},
@@ -199,7 +199,7 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 		{
 			description: "should fail because auth request session is missing subject claims",
 			areq: &fosite.AccessRequest{
-				GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+				GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 				Request: fosite.Request{
 					Client:  client,
 					Form:    url.Values{"device_code": []string{"device_code"}},
@@ -220,7 +220,7 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 		{
 			description: "should pass",
 			areq: &fosite.AccessRequest{
-				GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+				GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 				Request: fosite.Request{
 					Client:  client,
 					Form:    url.Values{"device_code": []string{"device_code"}},

--- a/handler/openid/flow_device_token_test.go
+++ b/handler/openid/flow_device_token_test.go
@@ -97,6 +97,7 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 			areq: &fosite.AccessRequest{
 				GrantTypes: fosite.Arguments{"authorization_code"},
 				Request: fosite.Request{
+					Client:  client,
 					Form:    url.Values{"device_code": []string{"device_code"}},
 					Session: session,
 				},
@@ -109,6 +110,7 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 			areq: &fosite.AccessRequest{
 				GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 				Request: fosite.Request{
+					Client:  client,
 					Form:    url.Values{"device_code": []string{"device_code"}},
 					Session: session,
 				},
@@ -124,6 +126,7 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 			areq: &fosite.AccessRequest{
 				GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 				Request: fosite.Request{
+					Client:  client,
 					Form:    url.Values{"device_code": []string{"device_code"}},
 					Session: session,
 				},
@@ -138,6 +141,7 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 			areq: &fosite.AccessRequest{
 				GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 				Request: fosite.Request{
+					Client:  client,
 					Form:    url.Values{"device_code": []string{"device_code"}},
 					Session: session,
 				},
@@ -145,6 +149,7 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 			setup: func(areq *fosite.AccessRequest) {
 				authreq := &fosite.DeviceRequest{
 					Request: fosite.Request{
+						Client:       client,
 						GrantedScope: fosite.Arguments{"email"},
 						Session:      session,
 					},
@@ -152,29 +157,6 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 				store.EXPECT().GetOpenIDConnectSession(gomock.Any(), gomock.Any(), areq).Return(authreq, nil)
 			},
 			expectErr: fosite.ErrMisconfiguration,
-		},
-		{
-			description: "should fail because auth request's client grant type is invalid",
-			areq: &fosite.AccessRequest{
-				GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
-				Request: fosite.Request{
-					Client: &fosite.DefaultClient{
-						GrantTypes: fosite.Arguments{"authorization_code"},
-					},
-					Form:    url.Values{"device_code": []string{"device_code"}},
-					Session: session,
-				},
-			},
-			setup: func(areq *fosite.AccessRequest) {
-				authreq := &fosite.DeviceRequest{
-					Request: fosite.Request{
-						GrantedScope: fosite.Arguments{"openid", "email"},
-						Session:      session,
-					},
-				}
-				store.EXPECT().GetOpenIDConnectSession(gomock.Any(), gomock.Any(), areq).Return(authreq, nil)
-			},
-			expectErr: fosite.ErrUnauthorizedClient,
 		},
 		{
 			description: "should fail because auth request is missing session",
@@ -189,6 +171,7 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 			setup: func(areq *fosite.AccessRequest) {
 				authreq := &fosite.DeviceRequest{
 					Request: fosite.Request{
+						Client:       client,
 						GrantedScope: fosite.Arguments{"openid", "email"},
 					},
 				}
@@ -209,6 +192,7 @@ func TestDeviceToken_PopulateTokenEndpointResponse(t *testing.T) {
 			setup: func(areq *fosite.AccessRequest) {
 				authreq := &fosite.DeviceRequest{
 					Request: fosite.Request{
+						Client:       client,
 						GrantedScope: fosite.Arguments{"openid", "email"},
 						Session:      NewDefaultSession(),
 					},

--- a/handler/rfc8628/token_handler_test.go
+++ b/handler/rfc8628/token_handler_test.go
@@ -79,9 +79,16 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 				expectErr   error
 			}{
 				{
-					description: "should fail because not responsible",
+					description: "should fail because not responsible for handling the request",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"12345678"},
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						Request: fosite.Request{
+							Client: &fosite.DefaultClient{
+								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+							},
+							Session:     &DefaultDeviceFlowSession{},
+							RequestedAt: time.Now().UTC(),
+						},
 					},
 					expectErr: fosite.ErrUnknownRequest,
 				},
@@ -90,7 +97,10 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 					areq: &fosite.AccessRequest{
 						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
 						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{""}},
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{""},
+							},
 							Session:     &DefaultDeviceFlowSession{},
 							RequestedAt: time.Now().UTC(),
 						},
@@ -102,12 +112,15 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 					areq: &fosite.AccessRequest{
 						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
 						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeDeviceCode)},
+							},
 							Session:     &DefaultDeviceFlowSession{},
 							RequestedAt: time.Now().UTC(),
 						},
 					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.DeviceRequest) {
+					setup: func(t *testing.T, areq *fosite.AccessRequest, _ *fosite.DeviceRequest) {
 						deviceCode, _, err := strategy.GenerateDeviceCode(context.TODO())
 						require.NoError(t, err)
 						areq.Form = url.Values{"device_code": {deviceCode}}
@@ -119,15 +132,23 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 					areq: &fosite.AccessRequest{
 						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
 						Request: fosite.Request{
-							Form:        url.Values{},
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+							Form: url.Values{},
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeDeviceCode)},
+							},
 							Session:     &DefaultDeviceFlowSession{},
 							RequestedAt: time.Now().UTC(),
 						},
 					},
 					authreq: &fosite.DeviceRequest{
 						Request: fosite.Request{
-							Client: &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeDeviceCode)},
+							},
+							RequestedScope: fosite.Arguments{"foo"},
+							GrantedScope:   fosite.Arguments{"foo"},
 							Session: &DefaultDeviceFlowSession{
 								ExpiresAt: map[fosite.TokenType]time.Time{
 									fosite.DeviceCode: time.Now().Add(-time.Hour).UTC(),
@@ -163,7 +184,9 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 					},
 					authreq: &fosite.DeviceRequest{
 						Request: fosite.Request{
-							Client: &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+							Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+							RequestedScope: fosite.Arguments{"foo"},
+							GrantedScope:   fosite.Arguments{"foo"},
 							Session: &DefaultDeviceFlowSession{
 								ExpiresAt: map[fosite.TokenType]time.Time{
 									fosite.DeviceCode: time.Now().Add(-time.Hour).UTC(),
@@ -187,14 +210,19 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 					areq: &fosite.AccessRequest{
 						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
 						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeDeviceCode)},
+							},
 							Session:     &DefaultDeviceFlowSession{},
 							RequestedAt: time.Now().UTC(),
 						},
 					},
 					authreq: &fosite.DeviceRequest{
 						Request: fosite.Request{
-							Client: &fosite.DefaultClient{ID: "bar"},
+							Client:         &fosite.DefaultClient{ID: "bar"},
+							RequestedScope: fosite.Arguments{"foo"},
+							GrantedScope:   fosite.Arguments{"foo"},
 							Session: &DefaultDeviceFlowSession{
 								ExpiresAt: map[fosite.TokenType]time.Time{
 									fosite.DeviceCode: time.Now().Add(time.Hour).UTC(),
@@ -217,14 +245,22 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 					areq: &fosite.AccessRequest{
 						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
 						Request: fosite.Request{
-							Client:      &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeDeviceCode)},
+							},
 							Session:     &DefaultDeviceFlowSession{},
 							RequestedAt: time.Now().UTC(),
 						},
 					},
 					authreq: &fosite.DeviceRequest{
 						Request: fosite.Request{
-							Client: &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+							Client: &fosite.DefaultClient{
+								ID:         "foo",
+								GrantTypes: []string{string(fosite.GrantTypeDeviceCode)},
+							},
+							RequestedScope: fosite.Arguments{"foo"},
+							GrantedScope:   fosite.Arguments{"foo"},
 							Session: &DefaultDeviceFlowSession{
 								BrowserFlowCompleted: true,
 							},
@@ -264,7 +300,7 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 	}
 }
 
-func TestDeviceUserCode_HandleTokenEndpointRequest_Ratelimitting(t *testing.T) {
+func TestDeviceUserCode_HandleTokenEndpointRequest_RateLimiting(t *testing.T) {
 	for k, strategy := range map[string]struct {
 		oauth2.CoreStrategy
 		RFC8628CodeStrategy
@@ -300,14 +336,15 @@ func TestDeviceUserCode_HandleTokenEndpointRequest_Ratelimitting(t *testing.T) {
 						ID:         "foo",
 						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
 					},
-					GrantedScope: fosite.Arguments{"foo", "offline"},
-					Session:      &DefaultDeviceFlowSession{},
-					RequestedAt:  time.Now().UTC(),
+					Session:     &DefaultDeviceFlowSession{},
+					RequestedAt: time.Now().UTC(),
 				},
 			}
 			authreq := &fosite.DeviceRequest{
 				Request: fosite.Request{
-					Client: &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+					Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+					RequestedScope: fosite.Arguments{"foo"},
+					GrantedScope:   fosite.Arguments{"foo"},
 					Session: &DefaultDeviceFlowSession{
 						BrowserFlowCompleted: true,
 					},
@@ -341,19 +378,27 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 		t.Run("strategy="+k, func(t *testing.T) {
 			store := storage.NewMemoryStore()
 
-			var h oauth2.GenericCodeTokenEndpointHandler
-
 			testCases := []struct {
-				areq        *fosite.AccessRequest
 				description string
-				setup       func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config)
+				areq        *fosite.AccessRequest
+				authreq     *fosite.DeviceRequest
+				setup       func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.DeviceRequest, config *fosite.Config)
 				check       func(t *testing.T, aresp *fosite.AccessResponse)
 				expectErr   error
 			}{
 				{
-					description: "should fail because not responsible",
+					description: "should fail because not responsible for handling the request",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{"123"},
+						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						Request: fosite.Request{
+							Client: &fosite.DefaultClient{
+								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+							},
+							Session: &DefaultDeviceFlowSession{
+								BrowserFlowCompleted: true,
+							},
+							RequestedAt: time.Now().UTC(),
+						},
 					},
 					expectErr: fosite.ErrUnknownRequest,
 				},
@@ -366,11 +411,13 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 							Client: &fosite.DefaultClient{
 								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
 							},
-							Session:     &DefaultDeviceFlowSession{},
+							Session: &DefaultDeviceFlowSession{
+								BrowserFlowCompleted: true,
+							},
 							RequestedAt: time.Now().UTC(),
 						},
 					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
+					setup: func(t *testing.T, areq *fosite.AccessRequest, _ *fosite.DeviceRequest, _ *fosite.Config) {
 						code, _, err := strategy.GenerateDeviceCode(context.TODO())
 						require.NoError(t, err)
 						areq.Form.Set("device_code", code)
@@ -378,7 +425,7 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 					expectErr: fosite.ErrServerError,
 				},
 				{
-					description: "should pass with offline scope and refresh token",
+					description: "should pass with offline scope and refresh token grant type",
 					areq: &fosite.AccessRequest{
 						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
 						Request: fosite.Request{
@@ -386,19 +433,29 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 							Client: &fosite.DefaultClient{
 								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode), string(fosite.GrantTypeRefreshToken)},
 							},
-							GrantedScope: fosite.Arguments{"foo", "offline"},
 							Session: &DefaultDeviceFlowSession{
 								BrowserFlowCompleted: true,
 							},
 							RequestedAt: time.Now().UTC(),
 						},
 					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
+					authreq: &fosite.DeviceRequest{
+						Request: fosite.Request{
+							Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+							RequestedScope: fosite.Arguments{"foo", "bar", "offline"},
+							GrantedScope:   fosite.Arguments{"foo", "offline"},
+							Session: &DefaultDeviceFlowSession{
+								BrowserFlowCompleted: true,
+							},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.DeviceRequest, _ *fosite.Config) {
 						code, signature, err := strategy.GenerateDeviceCode(context.TODO())
 						require.NoError(t, err)
 						areq.Form.Add("device_code", code)
 
-						require.NoError(t, store.CreateDeviceCodeSession(context.TODO(), signature, areq))
+						require.NoError(t, store.CreateDeviceCodeSession(context.TODO(), signature, authreq))
 					},
 					check: func(t *testing.T, aresp *fosite.AccessResponse) {
 						assert.NotEmpty(t, aresp.AccessToken)
@@ -409,7 +466,7 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 					},
 				},
 				{
-					description: "should pass with refresh token always provided",
+					description: "should pass with refresh token grant type",
 					areq: &fosite.AccessRequest{
 						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
 						Request: fosite.Request{
@@ -417,20 +474,30 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 							Client: &fosite.DefaultClient{
 								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode), string(fosite.GrantTypeRefreshToken)},
 							},
-							GrantedScope: fosite.Arguments{"foo"},
 							Session: &DefaultDeviceFlowSession{
 								BrowserFlowCompleted: true,
 							},
 							RequestedAt: time.Now().UTC(),
 						},
 					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
+					authreq: &fosite.DeviceRequest{
+						Request: fosite.Request{
+							Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+							RequestedScope: fosite.Arguments{"foo", "bar"},
+							GrantedScope:   fosite.Arguments{"foo"},
+							Session: &DefaultDeviceFlowSession{
+								BrowserFlowCompleted: true,
+							},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.DeviceRequest, config *fosite.Config) {
 						config.RefreshTokenScopes = []string{}
 						code, signature, err := strategy.GenerateDeviceCode(context.TODO())
 						require.NoError(t, err)
 						areq.Form.Add("device_code", code)
 
-						require.NoError(t, store.CreateDeviceCodeSession(context.TODO(), signature, areq))
+						require.NoError(t, store.CreateDeviceCodeSession(context.TODO(), signature, authreq))
 					},
 					check: func(t *testing.T, aresp *fosite.AccessResponse) {
 						assert.NotEmpty(t, aresp.AccessToken)
@@ -449,19 +516,29 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 							Client: &fosite.DefaultClient{
 								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
 							},
-							GrantedScope: fosite.Arguments{"foo"},
 							Session: &DefaultDeviceFlowSession{
 								BrowserFlowCompleted: true,
 							},
 							RequestedAt: time.Now().UTC(),
 						},
 					},
-					setup: func(t *testing.T, areq *fosite.AccessRequest, config *fosite.Config) {
+					authreq: &fosite.DeviceRequest{
+						Request: fosite.Request{
+							Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+							RequestedScope: fosite.Arguments{"foo", "bar"},
+							GrantedScope:   fosite.Arguments{"foo"},
+							Session: &DefaultDeviceFlowSession{
+								BrowserFlowCompleted: true,
+							},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest, authreq *fosite.DeviceRequest, config *fosite.Config) {
 						code, signature, err := strategy.GenerateDeviceCode(context.TODO())
 						require.NoError(t, err)
 						areq.Form.Add("device_code", code)
 
-						require.NoError(t, store.CreateDeviceCodeSession(context.TODO(), signature, areq))
+						require.NoError(t, store.CreateDeviceCodeSession(context.TODO(), signature, authreq))
 					},
 					check: func(t *testing.T, aresp *fosite.AccessResponse) {
 						assert.NotEmpty(t, aresp.AccessToken)
@@ -481,7 +558,7 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 						AccessTokenLifespan:      time.Minute,
 						RefreshTokenScopes:       []string{"offline"},
 					}
-					h = oauth2.GenericCodeTokenEndpointHandler{
+					h := oauth2.GenericCodeTokenEndpointHandler{
 						AccessRequestValidator: &DeviceAccessRequestValidator{},
 						CodeHandler: &DeviceCodeHandler{
 							DeviceRateLimitStrategy: strategy,
@@ -498,7 +575,7 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 					}
 
 					if testCase.setup != nil {
-						testCase.setup(t, testCase.areq, config)
+						testCase.setup(t, testCase.areq, testCase.authreq, config)
 					}
 
 					aresp := fosite.NewAccessResponse()
@@ -526,24 +603,37 @@ func TestDeviceUserCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 	var mockDeviceRateLimitStrategy *internal.MockDeviceRateLimitStrategy
 	strategy := hmacshaStrategy
 	deviceStrategy := RFC8628HMACSHAStrategy
-	request := &fosite.AccessRequest{
-		GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+
+	authreq := &fosite.DeviceRequest{
 		Request: fosite.Request{
-			Client: &fosite.DefaultClient{
-				GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode), string(fosite.GrantTypeRefreshToken)},
-			},
-			GrantedScope: fosite.Arguments{"offline"},
+			Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+			RequestedScope: fosite.Arguments{"foo", "offline"},
+			GrantedScope:   fosite.Arguments{"foo", "offline"},
 			Session: &DefaultDeviceFlowSession{
 				BrowserFlowCompleted: true,
 			},
 			RequestedAt: time.Now().UTC(),
 		},
 	}
-	token, _, err := deviceStrategy.GenerateDeviceCode(context.Background())
-	require.NoError(t, err)
-	request.Form = url.Values{"device_code": {token}}
-	response := fosite.NewAccessResponse()
+
+	areq := &fosite.AccessRequest{
+		GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+		Request: fosite.Request{
+			Client: &fosite.DefaultClient{
+				GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode), string(fosite.GrantTypeRefreshToken)},
+			},
+			Session: &DefaultDeviceFlowSession{
+				BrowserFlowCompleted: true,
+			},
+			RequestedAt: time.Now().UTC(),
+		},
+	}
+	aresp := fosite.NewAccessResponse()
 	propagatedContext := context.Background()
+
+	code, _, err := deviceStrategy.GenerateDeviceCode(context.Background())
+	require.NoError(t, err)
+	areq.Form = url.Values{"device_code": {code}}
 
 	// some storage implementation that has support for transactions, notice the embedded type `storage.Transactional`
 	type coreTransactionalStore struct {
@@ -567,7 +657,7 @@ func TestDeviceUserCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 				mockDeviceCodeStore.
 					EXPECT().
 					GetDeviceCodeSession(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(request, nil).
+					Return(authreq, nil).
 					Times(1)
 				mockTransactional.
 					EXPECT().
@@ -601,7 +691,7 @@ func TestDeviceUserCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 				mockDeviceCodeStore.
 					EXPECT().
 					GetDeviceCodeSession(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(request, nil).
+					Return(authreq, nil).
 					Times(1)
 				mockTransactional.
 					EXPECT().
@@ -626,7 +716,7 @@ func TestDeviceUserCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 				mockDeviceCodeStore.
 					EXPECT().
 					GetDeviceCodeSession(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(request, nil).
+					Return(authreq, nil).
 					Times(1)
 				mockTransactional.
 					EXPECT().
@@ -656,7 +746,7 @@ func TestDeviceUserCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 				mockDeviceCodeStore.
 					EXPECT().
 					GetDeviceCodeSession(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(request, nil).
+					Return(authreq, nil).
 					Times(1)
 				mockTransactional.
 					EXPECT().
@@ -671,7 +761,7 @@ func TestDeviceUserCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 				mockDeviceCodeStore.
 					EXPECT().
 					GetDeviceCodeSession(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(request, nil).
+					Return(authreq, nil).
 					Times(1)
 				mockTransactional.
 					EXPECT().
@@ -696,7 +786,7 @@ func TestDeviceUserCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 				mockDeviceCodeStore.
 					EXPECT().
 					GetDeviceCodeSession(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(request, nil).
+					Return(authreq, nil).
 					Times(1)
 				mockTransactional.
 					EXPECT().
@@ -743,7 +833,7 @@ func TestDeviceUserCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 			mockDeviceRateLimitStrategy = internal.NewMockDeviceRateLimitStrategy(ctrl)
 			testCase.setup()
 
-			handler := oauth2.GenericCodeTokenEndpointHandler{
+			h := oauth2.GenericCodeTokenEndpointHandler{
 				AccessRequestValidator: &DeviceAccessRequestValidator{},
 				CodeHandler: &DeviceCodeHandler{
 					DeviceRateLimitStrategy: mockDeviceRateLimitStrategy,
@@ -768,7 +858,7 @@ func TestDeviceUserCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 				},
 			}
 
-			if err = handler.PopulateTokenEndpointResponse(propagatedContext, request, response); testCase.expectError != nil {
+			if err = h.PopulateTokenEndpointResponse(propagatedContext, areq, aresp); testCase.expectError != nil {
 				assert.EqualError(t, err, testCase.expectError.Error())
 			}
 		})

--- a/handler/rfc8628/token_handler_test.go
+++ b/handler/rfc8628/token_handler_test.go
@@ -81,10 +81,10 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should fail because not responsible for handling the request",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+								GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 							},
 							Session:     &DefaultDeviceFlowSession{},
 							RequestedAt: time.Now().UTC(),
@@ -95,7 +95,7 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should fail because client is not granted the correct grant type",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+						GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
@@ -110,11 +110,11 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should fail because device code could not be retrieved",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+						GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeDeviceCode)},
+								GrantTypes: []string{"urn:ietf:params:oauth:grant-type:device_code"},
 							},
 							Session:     &DefaultDeviceFlowSession{},
 							RequestedAt: time.Now().UTC(),
@@ -130,12 +130,12 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should fail because user has not completed the browser flow",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+						GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeDeviceCode)},
+								GrantTypes: []string{"urn:ietf:params:oauth:grant-type:device_code"},
 							},
 							Session:     &DefaultDeviceFlowSession{},
 							RequestedAt: time.Now().UTC(),
@@ -145,7 +145,7 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeDeviceCode)},
+								GrantTypes: []string{"urn:ietf:params:oauth:grant-type:device_code"},
 							},
 							RequestedScope: fosite.Arguments{"foo"},
 							GrantedScope:   fosite.Arguments{"foo"},
@@ -170,12 +170,12 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should fail because device code has expired",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+						GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+								GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 							},
 							GrantedScope: fosite.Arguments{"foo", "offline"},
 							Session:      &DefaultDeviceFlowSession{},
@@ -184,7 +184,7 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 					},
 					authreq: &fosite.DeviceRequest{
 						Request: fosite.Request{
-							Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+							Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"urn:ietf:params:oauth:grant-type:device_code"}},
 							RequestedScope: fosite.Arguments{"foo"},
 							GrantedScope:   fosite.Arguments{"foo"},
 							Session: &DefaultDeviceFlowSession{
@@ -208,11 +208,11 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should fail because client mismatch",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+						GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeDeviceCode)},
+								GrantTypes: []string{"urn:ietf:params:oauth:grant-type:device_code"},
 							},
 							Session:     &DefaultDeviceFlowSession{},
 							RequestedAt: time.Now().UTC(),
@@ -243,11 +243,11 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should pass",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+						GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeDeviceCode)},
+								GrantTypes: []string{"urn:ietf:params:oauth:grant-type:device_code"},
 							},
 							Session:     &DefaultDeviceFlowSession{},
 							RequestedAt: time.Now().UTC(),
@@ -257,7 +257,7 @@ func TestDeviceUserCode_HandleTokenEndpointRequest(t *testing.T) {
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
 								ID:         "foo",
-								GrantTypes: []string{string(fosite.GrantTypeDeviceCode)},
+								GrantTypes: []string{"urn:ietf:params:oauth:grant-type:device_code"},
 							},
 							RequestedScope: fosite.Arguments{"foo"},
 							GrantedScope:   fosite.Arguments{"foo"},
@@ -329,12 +329,12 @@ func TestDeviceUserCode_HandleTokenEndpointRequest_RateLimiting(t *testing.T) {
 				},
 			}
 			areq := &fosite.AccessRequest{
-				GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+				GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 				Request: fosite.Request{
 					Form: url.Values{},
 					Client: &fosite.DefaultClient{
 						ID:         "foo",
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+						GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 					},
 					Session:     &DefaultDeviceFlowSession{},
 					RequestedAt: time.Now().UTC(),
@@ -342,7 +342,7 @@ func TestDeviceUserCode_HandleTokenEndpointRequest_RateLimiting(t *testing.T) {
 			}
 			authreq := &fosite.DeviceRequest{
 				Request: fosite.Request{
-					Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+					Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"urn:ietf:params:oauth:grant-type:device_code"}},
 					RequestedScope: fosite.Arguments{"foo"},
 					GrantedScope:   fosite.Arguments{"foo"},
 					Session: &DefaultDeviceFlowSession{
@@ -389,10 +389,10 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 				{
 					description: "should fail because not responsible for handling the request",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeAuthorizationCode)},
+						GrantTypes: fosite.Arguments{"authorization_code"},
 						Request: fosite.Request{
 							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+								GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 							},
 							Session: &DefaultDeviceFlowSession{
 								BrowserFlowCompleted: true,
@@ -405,11 +405,11 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 				{
 					description: "should fail because device code cannot be retrieved",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+						GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+								GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 							},
 							Session: &DefaultDeviceFlowSession{
 								BrowserFlowCompleted: true,
@@ -427,11 +427,11 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 				{
 					description: "should pass with offline scope and refresh token grant type",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+						GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode), string(fosite.GrantTypeRefreshToken)},
+								GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code", "refresh_token"},
 							},
 							Session: &DefaultDeviceFlowSession{
 								BrowserFlowCompleted: true,
@@ -441,7 +441,7 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 					},
 					authreq: &fosite.DeviceRequest{
 						Request: fosite.Request{
-							Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+							Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"urn:ietf:params:oauth:grant-type:device_code"}},
 							RequestedScope: fosite.Arguments{"foo", "bar", "offline"},
 							GrantedScope:   fosite.Arguments{"foo", "offline"},
 							Session: &DefaultDeviceFlowSession{
@@ -468,11 +468,11 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 				{
 					description: "should pass with refresh token grant type",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+						GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode), string(fosite.GrantTypeRefreshToken)},
+								GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code", "refresh_token"},
 							},
 							Session: &DefaultDeviceFlowSession{
 								BrowserFlowCompleted: true,
@@ -482,7 +482,7 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 					},
 					authreq: &fosite.DeviceRequest{
 						Request: fosite.Request{
-							Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+							Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"urn:ietf:params:oauth:grant-type:device_code"}},
 							RequestedScope: fosite.Arguments{"foo", "bar"},
 							GrantedScope:   fosite.Arguments{"foo"},
 							Session: &DefaultDeviceFlowSession{
@@ -510,11 +510,11 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 				{
 					description: "pass and response should not have refresh token",
 					areq: &fosite.AccessRequest{
-						GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+						GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 						Request: fosite.Request{
 							Form: url.Values{},
 							Client: &fosite.DefaultClient{
-								GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+								GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 							},
 							Session: &DefaultDeviceFlowSession{
 								BrowserFlowCompleted: true,
@@ -524,7 +524,7 @@ func TestDeviceUserCode_PopulateTokenEndpointResponse(t *testing.T) {
 					},
 					authreq: &fosite.DeviceRequest{
 						Request: fosite.Request{
-							Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+							Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"urn:ietf:params:oauth:grant-type:device_code"}},
 							RequestedScope: fosite.Arguments{"foo", "bar"},
 							GrantedScope:   fosite.Arguments{"foo"},
 							Session: &DefaultDeviceFlowSession{
@@ -606,7 +606,7 @@ func TestDeviceUserCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 
 	authreq := &fosite.DeviceRequest{
 		Request: fosite.Request{
-			Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{string(fosite.GrantTypeDeviceCode)}},
+			Client:         &fosite.DefaultClient{ID: "foo", GrantTypes: []string{"urn:ietf:params:oauth:grant-type:device_code"}},
 			RequestedScope: fosite.Arguments{"foo", "offline"},
 			GrantedScope:   fosite.Arguments{"foo", "offline"},
 			Session: &DefaultDeviceFlowSession{
@@ -617,10 +617,10 @@ func TestDeviceUserCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 	}
 
 	areq := &fosite.AccessRequest{
-		GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode)},
+		GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code"},
 		Request: fosite.Request{
 			Client: &fosite.DefaultClient{
-				GrantTypes: fosite.Arguments{string(fosite.GrantTypeDeviceCode), string(fosite.GrantTypeRefreshToken)},
+				GrantTypes: fosite.Arguments{"urn:ietf:params:oauth:grant-type:device_code", "refresh_token"},
 			},
 			Session: &DefaultDeviceFlowSession{
 				BrowserFlowCompleted: true,

--- a/integration/authorize_device_grant_request_test.go
+++ b/integration/authorize_device_grant_request_test.go
@@ -53,14 +53,14 @@ func runDeviceFlowTest(t *testing.T) {
 		{
 			description: "should fail with invalid_grant",
 			setup: func() {
-				fositeStore.Clients["device-client"].(*fosite.DefaultClient).GrantTypes = []string{string(fosite.GrantTypeAuthorizationCode)}
+				fositeStore.Clients["device-client"].(*fosite.DefaultClient).GrantTypes = []string{"authorization_code"}
 			},
 			err: true,
 			check: func(t *testing.T, token *goauth.DeviceAuthResponse, err error) {
 				assert.ErrorContains(t, err, "invalid_grant")
 			},
 			cleanUp: func() {
-				fositeStore.Clients["device-client"].(*fosite.DefaultClient).GrantTypes = []string{string(fosite.GrantTypeDeviceCode)}
+				fositeStore.Clients["device-client"].(*fosite.DefaultClient).GrantTypes = []string{"urn:ietf:params:oauth:grant-type:device_code"}
 			},
 		},
 		{
@@ -167,14 +167,14 @@ func runDeviceFlowAccessTokenTest(t *testing.T) {
 		{
 			description: "should fail with unauthorized client",
 			setup: func() {
-				fositeStore.Clients["device-client"].(*fosite.DefaultClient).GrantTypes = []string{string(fosite.GrantTypeAuthorizationCode)}
+				fositeStore.Clients["device-client"].(*fosite.DefaultClient).GrantTypes = []string{"authorization_code"}
 			},
 			params: []goauth.AuthCodeOption{},
 			check: func(t *testing.T, token *goauth.Token, err error) {
 				assert.ErrorContains(t, err, "unauthorized_client")
 			},
 			cleanUp: func() {
-				fositeStore.Clients["device-client"].(*fosite.DefaultClient).GrantTypes = []string{string(fosite.GrantTypeDeviceCode)}
+				fositeStore.Clients["device-client"].(*fosite.DefaultClient).GrantTypes = []string{"urn:ietf:params:oauth:grant-type:device_code"}
 			},
 		},
 		{

--- a/integration/authorize_device_grant_request_test.go
+++ b/integration/authorize_device_grant_request_test.go
@@ -152,7 +152,6 @@ func runDeviceFlowAccessTokenTest(t *testing.T) {
 		description string
 		setup       func()
 		params      []goauth.AuthCodeOption
-		err         bool
 		check       func(t *testing.T, token *goauth.Token, err error)
 		cleanUp     func()
 	}{
@@ -161,7 +160,6 @@ func runDeviceFlowAccessTokenTest(t *testing.T) {
 			setup: func() {
 			},
 			params: []goauth.AuthCodeOption{goauth.SetAuthURLParam("grant_type", "invalid_grant_type")},
-			err:    true,
 			check: func(t *testing.T, token *goauth.Token, err error) {
 				assert.ErrorContains(t, err, "invalid_request")
 			},
@@ -172,7 +170,6 @@ func runDeviceFlowAccessTokenTest(t *testing.T) {
 				fositeStore.Clients["device-client"].(*fosite.DefaultClient).GrantTypes = []string{string(fosite.GrantTypeAuthorizationCode)}
 			},
 			params: []goauth.AuthCodeOption{},
-			err:    true,
 			check: func(t *testing.T, token *goauth.Token, err error) {
 				assert.ErrorContains(t, err, "unauthorized_client")
 			},
@@ -184,7 +181,6 @@ func runDeviceFlowAccessTokenTest(t *testing.T) {
 			description: "should fail with invalid device code",
 			setup:       func() {},
 			params:      []goauth.AuthCodeOption{goauth.SetAuthURLParam("device_code", "invalid_device_code")},
-			err:         true,
 			check: func(t *testing.T, token *goauth.Token, err error) {
 				assert.ErrorContains(t, err, "invalid_grant")
 			},
@@ -194,7 +190,6 @@ func runDeviceFlowAccessTokenTest(t *testing.T) {
 			setup: func() {
 				oauthClient.ClientID = "invalid_client_id"
 			},
-			err: true,
 			check: func(t *testing.T, token *goauth.Token, err error) {
 				assert.ErrorContains(t, err, "invalid_client")
 			},
@@ -204,17 +199,18 @@ func runDeviceFlowAccessTokenTest(t *testing.T) {
 		},
 		{
 			description: "should pass",
-			setup:       func() {},
-			err:         false,
+			check: func(t *testing.T, token *goauth.Token, err error) {
+				assert.Equal(t, "bearer", token.TokenType)
+				assert.NotEmpty(t, token.AccessToken)
+			},
 		},
 	} {
 		t.Run(fmt.Sprintf("case=%d description=%s", k, c.description), func(t *testing.T) {
-			c.setup()
+			if c.setup != nil {
+				c.setup()
+			}
 
 			token, err := oauthClient.DeviceAccessToken(context.Background(), resp, c.params...)
-			if !c.err {
-				assert.NotEmpty(t, token.AccessToken)
-			}
 
 			if c.check != nil {
 				c.check(t, token, err)


### PR DESCRIPTION
This pull request tries to fix the refresh token not issued problem in device flow. Also tries to make some corrections in the tests.

Question:

- Not sure when the client will be a `ClientWithCustomTokenLifespans`. But from this [line](https://github.com/canonical/fosite/blob/canonical/handler/oauth2/flow_generic_code_token.go#L141), do we need to also add something for device flow grant type in [here](https://github.com/canonical/fosite/blob/canonical/client_with_custom_token_lifespans.go#L57)?